### PR TITLE
test: linking github tools to PR 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@
 
 # Test binary, built with `go test -c`
 *.test
+test
+test/*
 
 # Code coverage profiles and other test artifacts
 *.out
@@ -24,9 +26,19 @@ profile.cov
 go.work
 go.work.sum
 
-# env file
+# env and secret file
 .env
+.secret*
+secret/*
 
 # Editor/IDE
-# .idea/
-# .vscode/
+.idea/
+.vscode
+
+# logs file
+*.log
+*log
+
+# build
+.build/
+.obj/


### PR DESCRIPTION
This pull request is meant to test the implemented GitHub settings by linking opened issues, reviewers etc to be sure the GitHub project page - discord bot receives updates when events are happening on the repository.

No major changes, I only added ignored files to push something instead of an empty file.

NB: don't forget to add the Label "under review" to notify other people its being checked by someone