### PR TITLE
Fix(storage): user/org space db value update

### DIFF
--- a/backend/storage/internal/repository.go
+++ b/backend/storage/internal/repository.go
@@ -169,7 +169,7 @@ func (r *storageRepository) TryIncrementUserUsedSpace(userID uuid.UUID, delta in
 func (r *storageRepository) DecrementUserUsedSpace(userID uuid.UUID, delta int64) error {
 	return r.db.Table("users").
 		Where("id = ?", userID).
-		UpdateColumn("used_space", gorm.Expr("used_space - ?", delta)).Error
+		UpdateColumn("used_space", gorm.Expr("CASE WHEN used_space >= ? THEN used_space - ? ELSE 0 END", delta, delta)).Error
 }
 
 // Folders
@@ -406,5 +406,5 @@ func (r *storageRepository) TryIncrementOrgUsedSpace(orgID uuid.UUID, delta int6
 func (r *storageRepository) DecrementOrgUsedSpace(orgID uuid.UUID, delta int64) error {
 	return r.db.Table("organizations").
 		Where("id = ?", orgID).
-		UpdateColumn("used_space", gorm.Expr("used_space - ?", delta)).Error
+		UpdateColumn("used_space", gorm.Expr("CASE WHEN used_space >= ? THEN used_space - ? ELSE 0 END", delta, delta)).Error
 }

--- a/backend/storage/internal/repository.go
+++ b/backend/storage/internal/repository.go
@@ -48,6 +48,10 @@ type StorageRepository interface {
 	GetUserSpace(userID uuid.UUID) (usedSpace int64, maxSpace int64, err error)
 	TryIncrementUserUsedSpace(userID uuid.UUID, delta int64) (bool, error)
 	DecrementUserUsedSpace(userID uuid.UUID, delta int64) error
+
+	GetOrgSpace(orgID uuid.UUID) (usedSpace int64, maxSpace int64, err error)
+	TryIncrementOrgUsedSpace(orgID uuid.UUID, delta int64) (bool, error)
+	DecrementOrgUsedSpace(orgID uuid.UUID, delta int64) error
 }
 
 type storageRepository struct {
@@ -370,4 +374,37 @@ func (r *storageRepository) FindStalePendingFiles(age time.Duration) ([]File, er
 		return nil, err
 	}
 	return files, nil
+}
+
+func (r *storageRepository) GetOrgSpace(orgID uuid.UUID) (usedSpace int64, maxSpace int64, err error) {
+	var result struct {
+		UsedSpace int64
+		MaxSpace  int64
+	}
+
+	err = r.db.Table("organizations").
+		Select("used_space, max_space").
+		Where("id = ?", orgID).
+		Take(&result).Error
+	if err != nil {
+		return 0, 0, err
+	}
+
+	return result.UsedSpace, result.MaxSpace, nil
+}
+
+func (r *storageRepository) TryIncrementOrgUsedSpace(orgID uuid.UUID, delta int64) (bool, error) {
+	result := r.db.Table("organizations").
+		Where("id = ? AND used_space + ? <= max_space", orgID, delta).
+		UpdateColumn("used_space", gorm.Expr("used_space + ?", delta))
+	if result.Error != nil {
+		return false, result.Error
+	}
+	return result.RowsAffected == 1, nil
+}
+
+func (r *storageRepository) DecrementOrgUsedSpace(orgID uuid.UUID, delta int64) error {
+	return r.db.Table("organizations").
+		Where("id = ?", orgID).
+		UpdateColumn("used_space", gorm.Expr("used_space - ?", delta)).Error
 }

--- a/backend/storage/internal/service/service.go
+++ b/backend/storage/internal/service/service.go
@@ -88,7 +88,7 @@ func (s *storageService) RequestUploadURL(userID uuid.UUID, fileSize int64, fold
 	objectID = uuid.New()
 
 	var used, max int64
-	used, max, err = s.repo.GetUserSpace(userID)
+	used, max, err = s.getQuota(userID, orgID)
 	if err != nil {
 		return "", uuid.Nil, err
 	}
@@ -142,7 +142,7 @@ func (s *storageService) FinalizeUpload(userID uuid.UUID, objectID uuid.UUID, na
 
 	// incrementing space used by user in DB via a single `UPDATE users SET used_space = used_space + ? WHERE id = ?` query to avoid dataraces
 	var ok bool
-	ok, err = s.repo.TryIncrementUserUsedSpace(userID, file.FileSize)
+	ok, err = s.tryIncrementQuota(userID, file.OrgID, file.FileSize)
 	if err != nil {
 		return uuid.Nil, err
 	}
@@ -236,7 +236,7 @@ func (s *storageService) DeleteFile(userID uuid.UUID, fileID uuid.UUID) error {
 		return nil
 	}
 
-	if err := s.repo.DecrementUserUsedSpace(file.OwnerUserID, file.FileSize); err != nil {
+	if err := s.decrementQuota(file.OwnerUserID, file.OrgID, file.FileSize); err != nil {
 		return err
 	}
 
@@ -580,4 +580,26 @@ func (s *storageService) presignedBaseURL(hostname string) string {
 		return "https://" + s.env.DomainName
 	}
 	return "https://" + hostname + ":" + s.env.AppPort
+}
+
+
+func (s *storageService) getQuota(userID uuid.UUID, orgID *uuid.UUID) (int64, int64, error) {
+	if orgID == nil {
+		return s.repo.GetUserSpace(userID)
+	}
+	return s.repo.GetOrgSpace(*orgID)
+}
+
+func (s *storageService) tryIncrementQuota(userID uuid.UUID, orgID *uuid.UUID, delta int64) (bool, error) {
+	if orgID == nil {
+		return s.repo.TryIncrementUserUsedSpace(userID, delta)
+	}
+	return s.repo.TryIncrementOrgUsedSpace(*orgID, delta)
+}
+
+func (s *storageService) decrementQuota(userID uuid.UUID, orgID *uuid.UUID, delta int64) error {
+	if orgID == nil {
+		return s.repo.DecrementUserUsedSpace(userID, delta)
+	}
+	return s.repo.DecrementOrgUsedSpace(*orgID, delta)
 }

--- a/backend/storage/internal/service/service.go
+++ b/backend/storage/internal/service/service.go
@@ -140,6 +140,17 @@ func (s *storageService) FinalizeUpload(userID uuid.UUID, objectID uuid.UUID, na
 		return uuid.Nil, ErrForbidden
 	}
 
+	// rbac check for upload in organization: checks that the user still has the rights to Finalize an upload (can change between RequestURL and FinalizeUpload if the file is huge)
+	if err := s.rbac.CanCreateInFolder(userID, file.FolderID, file.OrgID); err != nil {
+		if errors.Is(err, rbac.ErrForbidden) {
+			return uuid.Nil, ErrForbidden
+		}
+		if errors.Is(err, rbac.ErrNotFound) {
+			return uuid.Nil, ErrNotFound
+		}
+		return uuid.Nil, err
+	}
+
 	// incrementing space used by user in DB via a single `UPDATE users SET used_space = used_space + ? WHERE id = ?` query to avoid dataraces
 	var ok bool
 	ok, err = s.tryIncrementQuota(userID, file.OrgID, file.FileSize)

--- a/backend/storage/internal/workers/consumer.go
+++ b/backend/storage/internal/workers/consumer.go
@@ -321,9 +321,16 @@ func (c *EventConsumer) sweepOrphanedElements(ctx context.Context) {
 				log.Printf("[WARN] sweep: DeleteFile call failed %s: %v", f.ID, err)
 				continue
 			}
-			// only case where we need to update the user used space. The other cases either didn't FinalizeUpload or completely delete users/organizations data which delete on cascade this db field
-			if err := c.repo.DecrementUserUsedSpace(f.OwnerUserID, f.FileSize); err != nil {
-				log.Printf("[WARN] sweep: DecrementUserUsedSpace failed for %s: %v", f.ID, err)
+
+			var decErr error
+			if f.OrgID != nil {
+				decErr = c.repo.DecrementOrgUsedSpace(*f.OrgID, f.FileSize)
+			} else {
+				decErr = c.repo.DecrementUserUsedSpace(f.OwnerUserID, f.FileSize)
+			}
+
+			if decErr != nil {
+				log.Printf("[WARN] sweep: decrement quota failed for %s: %v", f.ID, decErr)
 			} else {
 				log.Printf("[INFO] sweep: removed ghost DB row %s", f.ID)
 			}

--- a/backend/storage/internal/workers/consumer.go
+++ b/backend/storage/internal/workers/consumer.go
@@ -321,6 +321,7 @@ func (c *EventConsumer) sweepOrphanedElements(ctx context.Context) {
 				log.Printf("[WARN] sweep: DeleteFile call failed %s: %v", f.ID, err)
 				continue
 			}
+			log.Printf("[INFO] sweep: removed ghost DB row %s", f.ID)
 
 			var decErr error
 			if f.OrgID != nil {
@@ -330,9 +331,7 @@ func (c *EventConsumer) sweepOrphanedElements(ctx context.Context) {
 			}
 
 			if decErr != nil {
-				log.Printf("[WARN] sweep: decrement quota failed for %s: %v", f.ID, decErr)
-			} else {
-				log.Printf("[INFO] sweep: removed ghost DB row %s", f.ID)
+				log.Printf("[WARN] sweep: quota decrement failed for row %s (already removed): %v", f.ID, decErr)
 			}
 		}
 	}


### PR DESCRIPTION
Adds support for tracking and enforcing storage quotas at the organization level, fixing the existing user-level quotas.

**Organization quota support:**

* [`backend/storage/internal/repository.go`](diffhunk://#diff-8516391b390434d5d3aa112dceb6ae678b1c43ed83e6bea23555150078b6c315R51-R54): Added new methods to `StorageRepository` for getting, incrementing, and decrementing organization storage quotas (`GetOrgSpace`, `TryIncrementOrgUsedSpace`, `DecrementOrgUsedSpace`).

**Service logic updates:**

* [`backend/storage/internal/service/service.go`](diffhunk://#diff-390f2a058f76cd23e7c26245b32f30cf9d179f4628ba21cf88d219101bb0501fL91-R91): Introduced helper methods (`getQuota`, `tryIncrementQuota`, `decrementQuota`) to abstract quota operations for users or organizations, and updated all relevant service methods to use these helpers instead of user-only logic.

**Worker logic updates:**

* [`backend/storage/internal/workers/consumer.go`](diffhunk://#diff-83eb3bb46f5aabccd4e0003f69ec27e050c8de8a8ef7334473823fac902c0464L324-R333): Updated the sweep logic to decrement either the user or organization quota based on file ownership, ensuring correct quota management when cleaning up orphaned files.