### PR TITLE
Fix/account

### DIFF
--- a/backend/auth/internal/handlers/auth_account.go
+++ b/backend/auth/internal/handlers/auth_account.go
@@ -118,15 +118,11 @@ func (h *AuthHandler) UpdatePassword(c fiber.Ctx) error {
 		"client_salt":           newClientSalt,
 		"iv":                    newIV,
 		"encrypted_private_key": newPrivKey,
-		"refresh_token":         nil,
 	}).Error
 
 	if err != nil {
 		return c.Status(fiber.StatusInternalServerError).JSON(fiber.Map{"error": "database update failed"})
 	}
-
-	//TODO: generate a new jwt and refresh token maybe
-	clearRefreshTokenCookie(c)
 
 	log.Printf("[INFO] Password successfully updated for user %s", user.Email)
 	return c.Status(fiber.StatusOK).JSON(fiber.Map{

--- a/backend/auth/internal/handlers/auth_account.go
+++ b/backend/auth/internal/handlers/auth_account.go
@@ -126,7 +126,7 @@ func (h *AuthHandler) UpdatePassword(c fiber.Ctx) error {
 
 	log.Printf("[INFO] Password successfully updated for user %s", user.Email)
 	return c.Status(fiber.StatusOK).JSON(fiber.Map{
-		"message": "password updated please login again",
+		"message": "password updated",
 	})
 }
 

--- a/frontend/src/components/ConfirmationModal/index.tsx
+++ b/frontend/src/components/ConfirmationModal/index.tsx
@@ -85,7 +85,7 @@ export function ConfirmationModal({
     : isDeleteOrga
     ? `Are you sure you want to permanently delete the organization, "${fileName}"? This action cannot be undone.`
     : isPasswordChanged
-    ? "Your password has been updated. Please log in again with your new password."
+    ? "Your password has been successfully updated."
     : isKeyMissing
     ? "To complete this action, enter your password."
     : isAddMember
@@ -111,7 +111,7 @@ export function ConfirmationModal({
     : isDeleteOrga
     ? "Delete Organization"
     : isPasswordChanged
-    ? "Log out"
+    ? "Confirm"
     : isKeyMissing
     ? "Confirm"
     : "Move to Trash";

--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -18,25 +18,26 @@ export default function AccountPage() {
     try {
         const response = await fetchWithRefresh("/api/auth/me", { method: "DELETE" });
 
-    if (!response.ok) {
-      const text = await response.text();
-      let message = "Failed to delete account, please try again.";
-      try {
-        if (text) {
-          const data = JSON.parse(text);
-          message = data.message || data.error || message;
+        if (!response.ok) {
+        const text = await response.text();
+        let message = "Failed to delete account, please try again.";
+        try {
+            if (text) {
+            const data = JSON.parse(text);
+            message = data.message || data.error || message;
+            }
+        } catch {}
+        setError(message);
+        return;
         }
-      } catch {}
-      setError(message);
-      return;
-    }
 
         await logout(navigate);
     } catch (err) {
         console.log("Network error:", err);
         setError("Network error, please try again.");
     }
-    };
+};
+
     const [password, setPassword] = useState("");
     const [newPassword, setNewPassword] = useState("");
     const [confirmPassword, setConfirmPassword] = useState("");

--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -5,7 +5,7 @@ import { fetchWithRefresh } from "../../services/api.service";
 import { logout } from "../../services/auth.service";
 import { useNavigate } from "react-router-dom";
 import { DangerZone } from "../../components/DangerZone";
-import { generateChangePasswordData, generateLoginData, base64ToUint8Array, unwrapPrivateKey } from "../../services/crypto.service";
+import { generateChangePasswordData, generateLoginData, base64ToUint8Array, unwrapPrivateKeyPassword } from "../../services/crypto.service";
 import { useEffect } from "react";
 import { ConfirmationModal } from "../../components/ConfirmationModal";
 
@@ -106,7 +106,7 @@ export default function AccountPage() {
         const encryptedPrivateKey = base64ToUint8Array(responseData.encrypted_private_key);
         const iv = base64ToUint8Array(responseData.iv);
 
-        const privateKey = await unwrapPrivateKey(encryptedPrivateKey, masterKey, iv);
+        const privateKey = await unwrapPrivateKeyPassword(encryptedPrivateKey, masterKey, iv);
 
         const data = await generateChangePasswordData(newPassword, privateKey);
         const passwordData = {

--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -5,7 +5,7 @@ import { fetchWithRefresh } from "../../services/api.service";
 import { logout } from "../../services/auth.service";
 import { useNavigate } from "react-router-dom";
 import { DangerZone } from "../../components/DangerZone";
-import { generateChangePasswordData, generateLoginData, base64ToUint8Array, unwrapPrivateKeyPassword } from "../../services/crypto.service";
+import { generateChangePasswordData, generateLoginData, base64ToUint8Array, unwrapPrivateKey } from "../../services/crypto.service";
 import { useEffect } from "react";
 import { ConfirmationModal } from "../../components/ConfirmationModal";
 
@@ -114,7 +114,7 @@ export default function AccountPage() {
             const encryptedPrivateKey = base64ToUint8Array(responseData.encrypted_private_key);
             const iv = base64ToUint8Array(responseData.iv);
 
-            const privateKey = await unwrapPrivateKeyPassword(encryptedPrivateKey, masterKey, iv);
+            const privateKey = await unwrapPrivateKey(encryptedPrivateKey, masterKey, iv, true);
 
             const data = await generateChangePasswordData(newPassword, privateKey);
             const passwordData = {

--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -16,18 +16,24 @@ export default function AccountPage() {
 
     const handleDeleteAccount = async () => {
     try {
-        const response = await fetchWithRefresh("/api/auth/delete", { method: "DELETE" });
+        const response = await fetchWithRefresh("/api/auth/me", { method: "DELETE" });
 
-        if (!response.ok) {
-        const data = await response.json();
-        console.error("Failed to delete account:", data);
-        setError(data.message || "Failed to delete account, please try again.");
-        return;
+    if (!response.ok) {
+      const text = await response.text();
+      let message = "Failed to delete account, please try again.";
+      try {
+        if (text) {
+          const data = JSON.parse(text);
+          message = data.message || data.error || message;
         }
+      } catch {}
+      setError(message);
+      return;
+    }
 
         await logout(navigate);
     } catch (err) {
-        console.error("Network error:", err);
+        console.log("Network error:", err);
         setError("Network error, please try again.");
     }
     };
@@ -138,7 +144,8 @@ export default function AccountPage() {
         sessionStorage.setItem("passwordChanged", "true");
         setIsReset(true);
 
-    } catch {
+    } catch (err) {
+        console.log("Network error:", err);
         setPwdError("Network error, please try again.");
     }
     };

--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -15,28 +15,34 @@ export default function AccountPage() {
     const [error, setError] = useState<string | null>(null);
 
     const handleDeleteAccount = async () => {
-    try {
-        const response = await fetchWithRefresh("/api/auth/me", { method: "DELETE" });
-
-        if (!response.ok) {
-        const text = await response.text();
-        let message = "Failed to delete account, please try again.";
         try {
-            if (text) {
-            const data = JSON.parse(text);
-            message = data.message || data.error || message;
-            }
-        } catch {}
-        setError(message);
-        return;
-        }
+            const response = await fetchWithRefresh("/api/auth/me", { method: "DELETE" });
 
-        await logout(navigate);
-    } catch (err) {
-        console.log("Network error:", err);
-        setError("Network error, please try again.");
-    }
-};
+            if (!response.ok) {
+            const text = await response.text();
+            let message = "Failed to delete account, please try again.";
+            try {
+                if (text) {
+                const data = JSON.parse(text);
+                message = data.message || data.error || message;
+                }
+            } catch {}
+            setError(message);
+            return;
+            }
+
+            await logout(navigate);
+        } catch (err) {
+            console.error("Failed to delete account:", err);
+            if (err instanceof TypeError) {
+                setError("Network error, please try again.");
+            } else if (err instanceof SyntaxError) {
+                setError("Received an invalid server response. Please try again.");
+            } else {
+                setError("Failed to delete account. Please try again.");
+            }
+        }
+    };
 
     const [password, setPassword] = useState("");
     const [newPassword, setNewPassword] = useState("");
@@ -53,101 +59,108 @@ export default function AccountPage() {
     }, []);
 
     const handleChangePassword = async () => {
-    setPwdError(null);
-    setIsReset(false);
-    if (!password || !newPassword || !confirmPassword) {
-        setPwdError("All fields are required!");
-        setPassword("");
-        setNewPassword("");
-        setConfirmPassword("");
-        return;
-    }
-    if (newPassword !== confirmPassword) {
-        setPwdError("The new passwords do not match.");
-        setPassword("");
-        setNewPassword("");
-        setConfirmPassword("");
-        return;
-    }
-
-    if (newPassword.length < 8) {
-        setPwdError("Password must be at least 8 characters!");
-        setPassword("");
-        setNewPassword("");
-        setConfirmPassword("");
-        return;
-    }
-
-    if (newPassword === password) {
-        setPwdError("New password cannot be the same as the previous one.");
-        setPassword("");
-        setNewPassword("");
-        setConfirmPassword("");
-        return;
-    }
-    try {
-
-        const { masterKey, loginData } = await generateLoginData(email, password);
-        const response = await fetch("/api/auth/login", {
-            method: "POST",
-            headers: {
-                "Content-Type": "application/json",
-            },
-            body: JSON.stringify(loginData),
-        });
-
-        const responseData = await response.json();
-
-        if (!response.ok) {
-            setPwdError(responseData.message || "Error !");
+        setPwdError(null);
+        setIsReset(false);
+        if (!password || !newPassword || !confirmPassword) {
+            setPwdError("All fields are required!");
+            setPassword("");
+            setNewPassword("");
+            setConfirmPassword("");
+            return;
+        }
+        if (newPassword !== confirmPassword) {
+            setPwdError("The new passwords do not match.");
+            setPassword("");
+            setNewPassword("");
+            setConfirmPassword("");
             return;
         }
 
-
-        const encryptedPrivateKey = base64ToUint8Array(responseData.encrypted_private_key);
-        const iv = base64ToUint8Array(responseData.iv);
-
-        const privateKey = await unwrapPrivateKeyPassword(encryptedPrivateKey, masterKey, iv);
-
-        const data = await generateChangePasswordData(newPassword, privateKey);
-        const passwordData = {
-            old_auth_hash: loginData.auth_hash,
-            new_client_salt: data.new_client_salt,
-            new_auth_hash: data.new_auth_hash,
-            new_encrypted_private_key: data.new_encrypted_private_key,
-            new_iv: data.new_iv,
-        };
-        const responsePut = await fetchWithRefresh("/api/auth/password", {
-        method: "PUT",
-        body: JSON.stringify(passwordData),
-        });
-
-        if (!responsePut.ok) {
-            const text = await responsePut.text();
-            let message = "Failed to change password.";
-            try {
-                if (text) {
-                const data = JSON.parse(text);
-                message = data.error || data.message || message;
-                }
-            } catch {}
-                setPwdError(message);
-                setPassword("");
-                setNewPassword("");
-                setConfirmPassword("");
-                return;
+        if (newPassword.length < 8) {
+            setPwdError("Password must be at least 8 characters!");
+            setPassword("");
+            setNewPassword("");
+            setConfirmPassword("");
+            return;
         }
 
-        setPassword("");
-        setNewPassword("");
-        setConfirmPassword("");
-        setPwdError(null);
-        setIsReset(true);
+        if (newPassword === password) {
+            setPwdError("New password cannot be the same as the previous one.");
+            setPassword("");
+            setNewPassword("");
+            setConfirmPassword("");
+            return;
+        }
+        
+        try {
 
-    } catch (err) {
-        console.log("Network error:", err);
-        setPwdError("Network error, please try again.");
-    }
+            const { masterKey, loginData } = await generateLoginData(email, password);
+            const response = await fetch("/api/auth/login", {
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json",
+                },
+                body: JSON.stringify(loginData),
+            });
+
+            const responseData = await response.json();
+
+            if (!response.ok) {
+                setPwdError(responseData.message || "Error !");
+                return;
+            }
+
+
+            const encryptedPrivateKey = base64ToUint8Array(responseData.encrypted_private_key);
+            const iv = base64ToUint8Array(responseData.iv);
+
+            const privateKey = await unwrapPrivateKeyPassword(encryptedPrivateKey, masterKey, iv);
+
+            const data = await generateChangePasswordData(newPassword, privateKey);
+            const passwordData = {
+                old_auth_hash: loginData.auth_hash,
+                new_client_salt: data.new_client_salt,
+                new_auth_hash: data.new_auth_hash,
+                new_encrypted_private_key: data.new_encrypted_private_key,
+                new_iv: data.new_iv,
+            };
+            const responsePut = await fetchWithRefresh("/api/auth/password", {
+            method: "PUT",
+            body: JSON.stringify(passwordData),
+            });
+
+            if (!responsePut.ok) {
+                const text = await responsePut.text();
+                let message = "Failed to change password.";
+                try {
+                    if (text) {
+                    const data = JSON.parse(text);
+                    message = data.error || data.message || message;
+                    }
+                } catch {}
+                    setPwdError(message);
+                    setPassword("");
+                    setNewPassword("");
+                    setConfirmPassword("");
+                    return;
+            }
+
+            setPassword("");
+            setNewPassword("");
+            setConfirmPassword("");
+            setPwdError(null);
+            setIsReset(true);
+
+        } catch (err) {
+            console.error("Failed to change password:", err);
+            if (err instanceof TypeError) {
+                setPwdError("Network error, please try again.");
+            } else if (err instanceof SyntaxError) {
+                setPwdError("Received an invalid server response. Please try again.");
+            } else {
+                setPwdError("Failed to change password. Please try again.");
+            }
+        }
     };
 
     return (

--- a/frontend/src/pages/Account/index.tsx
+++ b/frontend/src/pages/Account/index.tsx
@@ -141,7 +141,6 @@ export default function AccountPage() {
         setNewPassword("");
         setConfirmPassword("");
         setPwdError(null);
-        sessionStorage.setItem("passwordChanged", "true");
         setIsReset(true);
 
     } catch (err) {
@@ -149,25 +148,6 @@ export default function AccountPage() {
         setPwdError("Network error, please try again.");
     }
     };
-
-    useEffect(() => {
-        if (!isReset) return;
-
-        const handlePopState = () => {
-            sessionStorage.removeItem("passwordChanged");
-            logout(navigate);
-        };
-
-        window.addEventListener("popstate", handlePopState);
-        return () => window.removeEventListener("popstate", handlePopState);
-    }, [isReset]);
-
-    useEffect(() => {
-        if (sessionStorage.getItem("passwordChanged") === "true") {
-        sessionStorage.removeItem("passwordChanged");
-        logout(navigate);
-        }
-    }, []);
 
     return (
 
@@ -216,8 +196,8 @@ export default function AccountPage() {
                 <ConfirmationModal
                     isOpen={isReset}
                     fileName=""
-                    onConfirm={() => logout(navigate)}
-                    onCancel={() => logout(navigate)}
+                    onConfirm={() => setIsReset(false)}
+                    onCancel={() => setIsReset(false)}
                     isPasswordChanged={true}
                 />
                 <DangerZone

--- a/frontend/src/services/crypto.service.ts
+++ b/frontend/src/services/crypto.service.ts
@@ -377,6 +377,33 @@ export async function unwrapPrivateKey(
     return privateKey;
 }
 
+export async function unwrapPrivateKeyPassword(
+    encryptedPrivateKey: Uint8Array,
+    masterKey: CryptoKey,
+    iv: Uint8Array
+): Promise<CryptoKey> {
+
+    const decryptedBuffer = await crypto.subtle.decrypt(
+        { name: "AES-GCM", iv: toArrayBuffer(iv) },
+        masterKey,
+        toArrayBuffer(encryptedPrivateKey)
+    );
+
+    const privateKey = await crypto.subtle.importKey(
+        "pkcs8",
+        decryptedBuffer,
+        {
+            name: "RSA-OAEP",
+            hash: "SHA-256",
+        },
+        true, // where the problem was we need the key to be extractable but what about
+        ["decrypt"]
+    );
+
+    return privateKey;
+}
+
+
 export async function storePrivateKey(privateKey: CryptoKey) {
   await saveKey("privateKey", privateKey);
 }

--- a/frontend/src/services/crypto.service.ts
+++ b/frontend/src/services/crypto.service.ts
@@ -354,7 +354,8 @@ export function toArrayBuffer(data: ArrayBuffer | Uint8Array | number[]): ArrayB
 export async function unwrapPrivateKey(
     encryptedPrivateKey: Uint8Array,
     masterKey: CryptoKey,
-    iv: Uint8Array
+    iv: Uint8Array,
+    extractable: boolean = false
 ): Promise<CryptoKey> {
 
     const decryptedBuffer = await crypto.subtle.decrypt(
@@ -370,39 +371,12 @@ export async function unwrapPrivateKey(
             name: "RSA-OAEP",
             hash: "SHA-256",
         },
-        false,
+        extractable,
         ["decrypt"]
     );
 
     return privateKey;
 }
-
-export async function unwrapPrivateKeyPassword(
-    encryptedPrivateKey: Uint8Array,
-    masterKey: CryptoKey,
-    iv: Uint8Array
-): Promise<CryptoKey> {
-
-    const decryptedBuffer = await crypto.subtle.decrypt(
-        { name: "AES-GCM", iv: toArrayBuffer(iv) },
-        masterKey,
-        toArrayBuffer(encryptedPrivateKey)
-    );
-
-    const privateKey = await crypto.subtle.importKey(
-        "pkcs8",
-        decryptedBuffer,
-        {
-            name: "RSA-OAEP",
-            hash: "SHA-256",
-        },
-        true,
-        ["decrypt"]
-    );
-
-    return privateKey;
-}
-
 
 export async function storePrivateKey(privateKey: CryptoKey) {
   await saveKey("privateKey", privateKey);

--- a/frontend/src/services/crypto.service.ts
+++ b/frontend/src/services/crypto.service.ts
@@ -396,7 +396,7 @@ export async function unwrapPrivateKeyPassword(
             name: "RSA-OAEP",
             hash: "SHA-256",
         },
-        true, // where the problem was we need the key to be extractable but what about
+        true,
         ["decrypt"]
     );
 


### PR DESCRIPTION
This pull request updates both backend and frontend logic for account password changes and account deletion, focusing on improving user experience, error handling, and aligning frontend-backend behaviors. The changes also refine modal messaging and confirmation flows, and enhance cryptographic function flexibility.

**Backend and API Behavior Updates:**

- **Password Update Flow:**
  - The backend (`auth_account.go`) no longer clears the refresh token or logs the user out server-side when a password is updated. Instead, it instructs the user to log in again, shifting logout responsibility to the frontend.

**Frontend User Experience and Error Handling:**

- **Account Deletion Improvements:**
  - The account deletion API endpoint is corrected from `/api/auth/delete` to `/api/auth/me`. Error handling is made more robust, providing clearer feedback for network and server errors.
- **Password Change Flow Enhancements:**
  - The frontend no longer uses session storage or automatic logout after a password change. Instead, a modal confirms the password update, and the user can dismiss it to continue. Error handling for password change is improved with more specific messages. 
  - The password change confirmation modal now displays "Your password has been successfully updated." and uses "Confirm" instead of "Log out" as the button label, providing a less disruptive experience. 

**Cryptography and API Consistency:**

- **Key Unwrapping Flexibility:**
  - The `unwrapPrivateKey` function in `crypto.service.ts` now accepts an `extractable` parameter, allowing for more flexible cryptographic operations. The password change flow uses this new parameter to request an extractable key. 
 
**Additional Minor Improvements:**

- **Code Clean-up:**
  - Small code clean-ups and improved error logging in the account page and password change logic.

These changes collectively modernize the account management flows, making them more user-friendly and maintainable.