### PR TITLE
Fix/org members display files folders

### DIFF
--- a/backend/orga/internal/handlers/orga_handler.go
+++ b/backend/orga/internal/handlers/orga_handler.go
@@ -482,6 +482,7 @@ func (h *OrgaHandler) GetOrgaInfo(c fiber.Ctx) error {
 	}
 
 	return c.Status(fiber.StatusOK).JSON(fiber.Map{
+		"user_id": userID,
 		"id":   orga.ID,
 		"name": orga.Name,
 		"used_space" : orga.UsedSpace,

--- a/backend/storage/internal/handlers/folders.go
+++ b/backend/storage/internal/handlers/folders.go
@@ -300,12 +300,12 @@ func (h *StorageHandler) ListOrgContents(c fiber.Ctx) error {
 
 	folderItems = make([]storage.FolderItem, len(folders))
 	for i, f := range folders {
-		folderItems[i] = storage.FolderItem{ID: f.ID, Name: f.Name, CreatedAt: f.CreatedAt}
+		folderItems[i] = storage.FolderItem{ID: f.ID, Name: f.Name, CreatedAt: f.CreatedAt, OwnerUserID: f.OwnerUserID}
 	}
 
 	filesItems = make([]storage.FilesItem, len(files))
 	for i, f := range files {
-		filesItems[i] = storage.FilesItem{ID: f.ID, Name: f.Name, FileSize: f.FileSize, CreatedAt: f.CreatedAt}
+		filesItems[i] = storage.FilesItem{ID: f.ID, Name: f.Name, FileSize: f.FileSize, CreatedAt: f.CreatedAt, OwnerUserID: f.OwnerUserID}
 	}
 
 	return c.Status(fiber.StatusOK).JSON(fiber.Map{

--- a/backend/storage/internal/models.go
+++ b/backend/storage/internal/models.go
@@ -47,6 +47,7 @@ type FolderItem struct {
 	ID			uuid.UUID	`json:"id"`
 	Name		string		`json:"name"`
 	CreatedAt	time.Time	`json:"created_at"`
+	OwnerUserID uuid.UUID	`json:"owner_user_id"`
 }
 
 type FilesItem struct {
@@ -54,4 +55,5 @@ type FilesItem struct {
 	Name		string		`json:"name"`
 	FileSize	int64		`json:"file_size"`
 	CreatedAt	time.Time	`json:"created_at"`
+	OwnerUserID uuid.UUID	`json:"owner_user_id"`
 }

--- a/frontend/src/components/FileCard/index.tsx
+++ b/frontend/src/components/FileCard/index.tsx
@@ -10,12 +10,15 @@ interface FileCardProps {
   name: string;
   fileSize: number;
   orgId?: string;
+  owner_user_id?: string;
+  role?: string;
+  user_id?: string;
   onDelete?: (id: string) => void;
   onDownload?: (id: string) => void;
   onMove?: (id: string, newParentId: string | null) => Promise<void>;
 }
 
-export function FileCard({ id, name, fileSize, orgId, onDelete, onDownload, onMove }: FileCardProps) {
+export function FileCard({ id, name, fileSize, orgId, owner_user_id, role, user_id, onDelete, onDownload, onMove }: FileCardProps) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showMoveModal, setShowMoveModal] = useState(false);
   const { decryptedName, loading } = useDecryptFilename(name, orgId);
@@ -59,16 +62,20 @@ export function FileCard({ id, name, fileSize, orgId, onDelete, onDownload, onMo
             <button className={styles.actionBtn} onClick={() => onDownload?.(id)} title="Download">
               <Download size={16} />
             </button>
-            <button className={styles.actionBtn} onClick={() => setShowMoveModal(true)} title="Move">
-              <Move size={16} />
-            </button>
-            <button
-              className={`${styles.actionBtn} ${styles.deleteBtn}`}
-              onClick={() => setShowDeleteModal(true)}
-              title="Delete"
-            >
-              <Trash2 size={16} />
-            </button>
+            {(!orgId || (orgId && role === "admin") || (orgId && owner_user_id === user_id)) && (
+              <>
+              <button className={styles.actionBtn} onClick={() => setShowMoveModal(true)} title="Move">
+                <Move size={16} />
+              </button>
+              <button
+                className={`${styles.actionBtn} ${styles.deleteBtn}`}
+                onClick={() => setShowDeleteModal(true)}
+                title="Delete"
+              >
+                <Trash2 size={16} />
+              </button>
+              </>
+            )}
           </div>
           <div className={styles.menuWrapper} ref={menuRef}>
             <button className={styles.menuBtn} onClick={() => setShowMenu(!showMenu)}>
@@ -79,12 +86,16 @@ export function FileCard({ id, name, fileSize, orgId, onDelete, onDownload, onMo
                 <button onClick={() => { onDownload?.(id); setShowMenu(false); }}>
                   <Download size={14} /> Download
                 </button>
+              {(!orgId || (orgId && role === "admin") || (orgId && owner_user_id === user_id)) && (
+                <>
                 <button onClick={() => { setShowMoveModal(true); setShowMenu(false); }}>
                   <Move size={14} /> Move
                 </button>
                 <button className={styles.deleteBtn} onClick={() => { setShowDeleteModal(true); setShowMenu(false); }}>
                   <Trash2 size={14} /> Delete
                 </button>
+                </>
+              )}
               </div>
             )}
           </div>

--- a/frontend/src/components/FolderCard/index.tsx
+++ b/frontend/src/components/FolderCard/index.tsx
@@ -10,12 +10,15 @@ interface FolderProps {
   name: string;
   createdAt: string;
   orgId?: string;
+  owner_user_id?: string;
+  role?: string;
+  user_id?: string;
   onDelete?: (id: string) => void;
   onRename?: (id: string, newName: string) => Promise<void>;
   onMove?: (id: string, newParentId: string | null) => Promise<void>;
 }
 
-export function FolderCard({ id, name, createdAt, orgId, onDelete, onRename, onMove }: FolderProps) {
+export function FolderCard({ id, name, createdAt, orgId, owner_user_id, role, user_id, onDelete, onRename, onMove }: FolderProps) {
   const [showMenu, setShowMenu] = useState(false);
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showRenameModal, setShowRenameModal] = useState(false);
@@ -83,25 +86,26 @@ export function FolderCard({ id, name, createdAt, orgId, onDelete, onRename, onM
             <span className={styles.name}>{name}</span>
             <span className={styles.date}>{date}</span>
         </div>
-
-        <div className={styles.menuWrapper} ref={menuRef} onClick={(e) => e.stopPropagation()}>
-            <button className={styles.menuBtn} onClick={() => setShowMenu(!showMenu)}>
-            <MoreVertical size={16} />
-            </button>
-            {showMenu && (
-            <div className={styles.dropdown}>
-                <button onClick={() => { setShowRenameModal(true); setShowMenu(false); }}>
-                <Pencil size={14} /> Rename
-                </button>
-                <button onClick={() => { setShowMoveModal(true); setShowMenu(false); }}>
-                <Move size={14} /> Move
-                </button>
-                <button className={styles.deleteBtn} onClick={() => { setShowDeleteModal(true); setShowMenu(false); }}>
-                <Trash2 size={14} /> Delete
-                </button>
-            </div>
-            )}
-        </div>
+        {(!orgId || (orgId && role === "admin") || (orgId && owner_user_id === user_id)) && (
+          <div className={styles.menuWrapper} ref={menuRef} onClick={(e) => e.stopPropagation()}>
+              <button className={styles.menuBtn} onClick={() => setShowMenu(!showMenu)}>
+              <MoreVertical size={16} />
+              </button>
+              {showMenu && (
+              <div className={styles.dropdown}>
+                  <button onClick={() => { setShowRenameModal(true); setShowMenu(false); }}>
+                  <Pencil size={14} /> Rename
+                  </button>
+                  <button onClick={() => { setShowMoveModal(true); setShowMenu(false); }}>
+                  <Move size={14} /> Move
+                  </button>
+                  <button className={styles.deleteBtn} onClick={() => { setShowDeleteModal(true); setShowMenu(false); }}>
+                  <Trash2 size={14} /> Delete
+                  </button>
+              </div>
+              )}
+          </div>
+        )}
         </div>
 
       <ConfirmationModal

--- a/frontend/src/pages/Orgs/OrgFilesPage.tsx
+++ b/frontend/src/pages/Orgs/OrgFilesPage.tsx
@@ -23,6 +23,9 @@ export default function OrgFilesPage() {
   const { registerListener, unregisterListener } = useNotifications();
   const [orgName, setOrgName] = useState<string>("");
   const [orgDesc, setOrgDesc] = useState<string>("");
+  const [myRole, setMyRole] = useState<string>("");
+  const [userID, setUserID] = useState<string>("");
+  
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -32,7 +35,7 @@ export default function OrgFilesPage() {
         if (!res.ok) throw new Error();
         return res.json();
       })
-      .then(data => { if (data) { setOrgName(data.name); setOrgDesc(data.description); } })
+      .then(data => { if (data) { setOrgName(data.name); setOrgDesc(data.description); setMyRole(data.role); setUserID(data.user_id)} })
       .catch(() => setOrgName("Unknown"));
   }, [id]);
 
@@ -188,6 +191,9 @@ export default function OrgFilesPage() {
                                         onRename={handleRenameFolder}
                                         onMove={handleMoveFolder}
                                         orgId={id}
+                                        role={myRole}
+                                        owner_user_id={folder.owner_user_id}
+                                        user_id={userID}
                                     />
                                     ))}
                                 </div>
@@ -209,6 +215,9 @@ export default function OrgFilesPage() {
                                         onDownload={handleDownload}
                                         onMove={handleMoveFile}
                                         orgId={id}
+                                        role={myRole}
+                                        owner_user_id={file.owner_user_id}
+                                        user_id={userID}
                                     />
                                     ))}
                                 </div>

--- a/frontend/src/services/files.service.ts
+++ b/frontend/src/services/files.service.ts
@@ -9,6 +9,7 @@ export interface FileItem {
     file_size: number;
     created_at: string;
     folder_id?: string;
+    owner_user_id?: string;
 }
 
 export interface FolderItem {
@@ -16,6 +17,7 @@ export interface FolderItem {
     name: string;
     created_at: string;
     parent_id?: string;
+    owner_user_id?: string;
 }
 
 export interface FolderContents {


### PR DESCRIPTION
This pull request implements user-based access control for file and folder actions in organization storage, ensuring that only admins or owners can move or delete items. It does so by propagating ownership and role information from the backend to the frontend, and conditionally rendering action buttons based on the current user's permissions.

**Backend changes:**

* Ownership tracking:
  * Added `OwnerUserID` field to the `FolderItem` and `FilesItem` structs in `models.go`, and included this field in the API responses for listing organization folders and files.

* User context in organization info:
  * The organization info API now includes the requesting user's ID in its response.

**Frontend changes:**

* Propagation of ownership and role data:
  * Updated `FileCard` and `FolderCard` components to accept and use `owner_user_id`, `role`, and `user_id` props. These are now passed from the organization files page, which fetches and stores the user's role and ID from the backend.

* Conditional action rendering:
  * Move and delete actions for files and folders are now only shown if the user is an admin or the owner of the item, or if the item is not tied to an organization.

These changes improve security and user experience by ensuring only authorized users can modify or delete organization files and folders.\

Close #108 