### PR TITLE
ci: linter action add the health-aggregator service

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        service: [storage, auth, orga, shared]
+        service: [storage, auth, orga, shared, health-aggregator]
     steps:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6

--- a/backend/health-aggregator/internal/handlers/health.go
+++ b/backend/health-aggregator/internal/handlers/health.go
@@ -77,7 +77,7 @@ func (h *HealthHandler) checkService(url string) *serviceStatus {
 		}
 	}
 
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	var status serviceStatus
 


### PR DESCRIPTION
Fixing a lint error in the health-aggregator service and adding it to the list of services checked by the github action