### PR TITLE
Fix/upload download

### DIFF
--- a/frontend/src/hooks/useE2EEDownloadOrg.ts
+++ b/frontend/src/hooks/useE2EEDownloadOrg.ts
@@ -6,9 +6,9 @@ import {
 } from '../services/crypto.service';
 import { decryptOrgPrivateKey } from '../services/organizations.service';
 import { fetchWithRefresh } from '../services/api.service';
+import { UPLOAD_CONFIG } from '../config/uploadConfig';
 
-const CHUNK_SIZE = 5 * 1024 * 1024; // 5 Mo
-const CIPHER_CHUNK_SIZE = CHUNK_SIZE + 16;
+const CIPHER_CHUNK_SIZE = UPLOAD_CONFIG.CHUNK_SIZE + 16;
 
 interface DownloadMetadata {
     presigned_url: string;


### PR DESCRIPTION
This pull request updates the chunk size configuration in the `useE2EEDownloadOrg` hook to use a centralized value from the `UPLOAD_CONFIG` file instead of a hardcoded constant. This change helps ensure consistency across the codebase and makes it easier to manage chunk size settings.

Configuration management:

* Replaced the hardcoded `CHUNK_SIZE` with `UPLOAD_CONFIG.CHUNK_SIZE` and updated `CIPHER_CHUNK_SIZE` accordingly in `frontend/src/hooks/useE2EEDownloadOrg.ts`.