### PR TITLE
Fix/orga redirection

### DIFF
--- a/backend/auth/internal/handlers/auth_account.go
+++ b/backend/auth/internal/handlers/auth_account.go
@@ -86,7 +86,7 @@ func (h *AuthHandler) DeleteUser(c fiber.Ctx) error {
 		}
 
 		for _, orgIDStr := range orgIDs {
-			// Get org nam
+			// Get org name
 			var orgName string
  			if err := tx.Table("organizations").Where("id = ?", orgIDStr).Select("name").Scan(&orgName).Error; err != nil {
  				return err

--- a/backend/auth/internal/workers/publisher.go
+++ b/backend/auth/internal/workers/publisher.go
@@ -143,7 +143,7 @@ func (p *EventPublisher) PublishToUser(ctx context.Context, orgID string, userID
 	}
 
 	event := WSEvent{
-		Event:   "ROLE UPDATED",
+		Event:   "ROLE_UPDATED",
 		Message: "Your role has changed to admin in organization [" + orgName +"]",
 		Data: map[string]interface{}{
 			"org_id": orgID,

--- a/frontend/src/components/ConfirmationModal/index.tsx
+++ b/frontend/src/components/ConfirmationModal/index.tsx
@@ -176,7 +176,15 @@ export function ConfirmationModal({
                     onInputChange?.("");
                     onCancel();
                 }} />
-            <div className={styles.modal}>
+            <form 
+                className={styles.modal} 
+                onSubmit={(e) => {
+                    e.preventDefault();
+                    if (!isLoading) {
+                        handleConfirm();
+                    }
+                }}
+            >
                 <h2 className={styles.modal__title}>{title}</h2>
                 {message && <p className={styles.modal__message}>{message}</p>}
                 {(isCreateOrga || isAddMember || isKeyMissing || isCreateFolder || isRenameFolder || isMove) && (
@@ -194,18 +202,28 @@ export function ConfirmationModal({
                 <p className={styles.modal__error}>{errorMessage}</p>
                 )}
                 <div className={styles.modal__actions}>
-                    { !isPasswordChanged && (<button className={`${styles.modal__button} ${styles["modal__button--cancel"]}`} 
-                          onClick={() => {
-                            onInputChange?.("");
-                            onCancel();
-                        }} disabled={isLoading}>
-                        Cancel
-                    </button>)}
-                    <button className={`${styles.modal__button} ${styles["modal__button--confirm"]}`} onClick={handleConfirm} disabled={isLoading}>
+                    { !isPasswordChanged && (
+                        <button 
+                            type="button"
+                            className={`${styles.modal__button} ${styles["modal__button--cancel"]}`} 
+                            onClick={() => {
+                                onInputChange?.("");
+                                onCancel();
+                            }} 
+                            disabled={isLoading}
+                        >
+                            Cancel
+                        </button>
+                    )}
+                    <button 
+                        type="submit" 
+                        className={`${styles.modal__button} ${styles["modal__button--confirm"]}`} 
+                        disabled={isLoading}
+                    >
                         {buttonText}
                     </button>
                 </div>
-            </div>
+            </form>
         </>
     );
 }

--- a/frontend/src/pages/Orgs/OrgMembersPage.tsx
+++ b/frontend/src/pages/Orgs/OrgMembersPage.tsx
@@ -93,7 +93,9 @@ export default function OrgMembersPage() {
     fetchWithRefresh(`/api/orgs/${id}/members`, { signal })
       .then(res => {
         if (res.status === 404 || res.status === 400) {
-          navigate("/404");
+            if (window.location.pathname.includes(`/orgs/${id}`)) {
+            navigate("/404");
+          }
           return null;
         }
         if (!res.ok) {
@@ -234,9 +236,9 @@ export default function OrgMembersPage() {
       }
     } catch {}
 
+    addMessage(`${memberEmail} added to ${orgName}`, "success");
     setMemberEmail("");
     setShowAddMemberModal(false);
-    addMessage(`${memberEmail} added to ${orgName}`, "success");
   };
 
   const handleChangeRole = async () => {
@@ -261,16 +263,20 @@ export default function OrgMembersPage() {
       setMembers(prev => prev.map(m =>
         m.user_id === selectedMember.user_id ? { ...m, role: newRole } : m
       ));
+      addMessage(`${selectedMember.email} successfully changed role`, "success");
       setShowChangeRoleModal(false);
       setSelectedMember(null);
-      addMessage(`${selectedMember.email} successfully changed role`, "success");
     } catch {
       setModalError("Network error, please try again later.");
     }
   };
 
-  const handleRemoveMember = async () => {
+const handleRemoveMember = async () => {
     if (!memberToRemove) return;
+
+    const isRemovingMyself = memberToRemove.user_id === myUserId;
+    const removedEmail = memberToRemove.email;
+
     try {
       const response = await fetchWithRefresh(`/api/orgs/${id}/members/${memberToRemove.user_id}`, { method: "DELETE" });
   
@@ -284,10 +290,18 @@ export default function OrgMembersPage() {
           return;
       }
   
+      if (isRemovingMyself) {
+        addMessage("You have successfully left the organization", "success");
+        setShowRemoveModal(false);
+        setMemberToRemove(null);
+        navigate("/organizations");
+        return;
+      }
+
       setMembers(prev => prev.filter(m => m.user_id !== memberToRemove.user_id));
+      addMessage(`${removedEmail} was removed from ${orgName}`, "success");
       setShowRemoveModal(false);
       setMemberToRemove(null);
-      addMessage(`${memberToRemove.email} was removed from ${orgName}`, "success");
     } catch {
       setModalError("Network error, please try again later.");
     }

--- a/frontend/src/pages/Orgs/OrgMembersPage.tsx
+++ b/frontend/src/pages/Orgs/OrgMembersPage.tsx
@@ -291,7 +291,6 @@ export default function OrgMembersPage() {
       }
   
       if (isRemovingMyself) {
-        addMessage("You have successfully left the organization", "success");
         setShowRemoveModal(false);
         setMemberToRemove(null);
         navigate("/organizations");

--- a/frontend/src/pages/Orgs/OrgMembersPage.tsx
+++ b/frontend/src/pages/Orgs/OrgMembersPage.tsx
@@ -94,8 +94,8 @@ export default function OrgMembersPage() {
       .then(res => {
         if (res.status === 404 || res.status === 400) {
             if (window.location.pathname.includes(`/orgs/${id}`)) {
-            navigate("/404");
-          }
+              navigate("/404");
+            }
           return null;
         }
         if (!res.ok) {
@@ -271,7 +271,7 @@ export default function OrgMembersPage() {
     }
   };
 
-const handleRemoveMember = async () => {
+  const handleRemoveMember = async () => {
     if (!memberToRemove) return;
 
     const isRemovingMyself = memberToRemove.user_id === myUserId;


### PR DESCRIPTION
This pull request refactors the `ConfirmationModal` component to use a form element for improved accessibility and UX, and refines the organization members management logic in `OrgMembersPage` for better navigation, feedback, and error handling. The changes enhance user experience when adding, removing, or changing the role of organization members.

**Organization Members page enhancements:**

* Improved navigation logic so that if a 404 or 400 error occurs while fetching organization members, the user is redirected to the 404 page only if they are on the relevant organization path.
* Ensured that success messages for adding a member, changing a role, or removing a member are shown immediately after the operation, and clarified the order of state updates for a more predictable user experience.
* Added logic to handle the case where a user removes themselves from an organization: after self-removal, the user is redirected to the organizations list page. 

**Confirmation Modal improvements:**

* Refactored the `ConfirmationModal` to use a `<form>` element with a submit handler instead of a `<div>`, ensuring that the confirm action is properly triggered on form submission and improving accessibility. The cancel button is now explicitly set to `type="button"` and the confirm button to `type="submit"`.

close #146 