### PR TITLE
fix: replace inline size formatting with utility functions for better…

### DIFF
--- a/frontend/src/components/FileCard/index.tsx
+++ b/frontend/src/components/FileCard/index.tsx
@@ -19,6 +19,7 @@ import { MoveModal } from "../MoveModal";
 import { useDecryptFilename } from "../../hooks/useDecryptFilename";
 import { useKeyCheck } from "../../hooks/useKeyCheck";
 import { FilePreviewModal } from "../FilePreviewModal";
+import { formatFileSize, getDecryptedSize } from "../../services/fileValidation.service";
 
 interface FileCardProps {
   id: string;
@@ -122,12 +123,6 @@ export function FileCard({ id, name, fileSize, orgId, owner_user_id, role, user_
     setShowPreviewModal(true);
   }
 
-  const formatSize = (bytes: number) => {
-    if (bytes < 1024) return `${bytes} B`;
-    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-    return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-  };
-
   const menuRef = useRef<HTMLDivElement>(null);
   const [showMenu, setShowMenu] = useState(false);
 
@@ -168,7 +163,7 @@ export function FileCard({ id, name, fileSize, orgId, owner_user_id, role, user_
           <span className={styles.name}>{displayName}</span>
         </div>
         <div className={styles.right}>
-          <span className={styles.size}>{formatSize(fileSize)}</span>
+          <span className={styles.size}>{formatFileSize(getDecryptedSize(fileSize))}</span>
           <div className={styles.actions}>
             <button className={styles.actionBtn} onClick={() => handlePreviewClick()} title="Preview">
               <Eye size={16} />

--- a/frontend/src/components/FilePreviewModal/index.tsx
+++ b/frontend/src/components/FilePreviewModal/index.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { useE2EEPreview } from "../../hooks/useE2EEPreview";
 import styles from "./FilePreviewModal.module.css";
+import { formatFileSize, getDecryptedSize } from "../../services/fileValidation.service";
 
 interface FilePreviewModalProps {
     isOpen: boolean;
@@ -144,12 +145,6 @@ export function FilePreviewModal({
 
     if (!isOpen) return null;
 
-    const formatSize = (bytes: number) => {
-        if (bytes < 1024) return `${bytes} B`;
-        if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
-        return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
-    };
-
     const handleDownloadInstant = () => {
         if (!blob) return;
         const url = URL.createObjectURL(blob);
@@ -180,7 +175,7 @@ export function FilePreviewModal({
                         </div>
                         <div className={styles.meta}>
                             <h3 className={styles.fileName} title={fileName}>{fileName}</h3>
-                            <span className={styles.fileSize}>{formatSize(fileSize)}</span>
+                            <span className={styles.fileSize}>{formatFileSize(blob ? blob.size : getDecryptedSize(fileSize))}</span>
                         </div>
                     </div>
 

--- a/frontend/src/services/fileValidation.service.ts
+++ b/frontend/src/services/fileValidation.service.ts
@@ -1,6 +1,7 @@
 import { fileTypeFromBuffer } from 'file-type';
 import MIME_TYPES_RAW from '../config/mime.types?raw';
 import { fileSchema } from '../schemas/file.schema';
+import { UPLOAD_CONFIG } from '../config/uploadConfig';
 
 const parseMimeTypes = (raw: string): Record<string, string[]> => {
     const types: Record<string, string[]> = {};
@@ -87,6 +88,15 @@ export const formatFileSize = (bytes: number): string => {
     const i = Math.floor(Math.log(bytes) / Math.log(k));
     return parseFloat((bytes / Math.pow(k, i)).toFixed(2)) + ' ' + sizes[i];
 };
+
+export const getDecryptedSize = (encryptedSize: number): number => {
+    if (encryptedSize <= 0) return 0;
+    const chunkSize = UPLOAD_CONFIG.CHUNK_SIZE;
+    const cipherChunkSize = chunkSize + 16;
+    const numChunks = Math.ceil(encryptedSize / cipherChunkSize);
+    return encryptedSize - numChunks * 16;
+};
+
 
 export const getFileTypeLabel = (mimeType: string): string => {
     const typeMap: Record<string, string> = {


### PR DESCRIPTION
This pull request refactors how file sizes are displayed in both the `FileCard` and `FilePreviewModal` components by centralizing and improving file size formatting and decryption logic. The main changes include removing duplicate formatting code, introducing a utility to calculate decrypted file size, and ensuring consistent display of file sizes across the UI.

**File size formatting and decryption improvements:**

* Replaced local `formatSize` functions in both `FileCard` and `FilePreviewModal` with the shared `formatFileSize` utility from `fileValidation.service.ts` for consistent file size formatting.
* Updated file size display to show the decrypted file size using the new `getDecryptedSize` utility, ensuring users see the actual file size post-decryption in both components.

**Utility and configuration enhancements:**

* Added `getDecryptedSize` function to `fileValidation.service.ts`, which calculates the decrypted size from the encrypted file size based on chunking and encryption overhead.
* Imported `UPLOAD_CONFIG` into `fileValidation.service.ts` to access encryption chunk size constants.

**Code cleanup and maintainability:**

* Removed redundant `formatSize` functions from both `FileCard` and `FilePreviewModal` and replaced them with shared utilities.
* Ensured all relevant files import the shared utilities for file size formatting and decryption. 

CLOSE #156 