### PR TITLE
Fix/notifications

### DIFF
--- a/backend/orga/internal/ws/ws_handler.go
+++ b/backend/orga/internal/ws/ws_handler.go
@@ -254,11 +254,36 @@ func (h *Hub) enrichEventMessage(payload []byte, orgNames map[string]string) []b
 	case "file_deleted":
 		enrichedMsg = fmt.Sprintf("[%s] A file has been deleted", orgName)
 	case "folder_created":
-		enrichedMsg = fmt.Sprintf("[%s] A new folder has been created", orgName)
-	case "folder_deleted":
-		enrichedMsg = fmt.Sprintf("[%s] A folder has been deleted", orgName)
-	case "folder_renamed":
-		enrichedMsg = fmt.Sprintf("[%s] A folder has been renamed", orgName)
+        folderName, _ := data["name"].(string)
+        if folderName != "" {
+            enrichedMsg = fmt.Sprintf("[%s] folder created: %s", orgName, folderName)
+        } else {
+            enrichedMsg = fmt.Sprintf("[%s] folder created", orgName)
+        }
+
+    case "folder_deleted":
+        folderName, _ := data["name"].(string)
+        if folderName != "" {
+            enrichedMsg = fmt.Sprintf("[%s] folder deleted: %s", orgName, folderName)
+        } else {
+            enrichedMsg = fmt.Sprintf("[%s] folder deleted", orgName)
+        }
+
+    case "folder_renamed":
+        oldName, _ := data["old_name"].(string)
+        newName, _ := data["new_name"].(string)
+        if newName == "" {
+            newName, _ = data["name"].(string)
+        }
+
+        if oldName != "" && newName != "" {
+            enrichedMsg = fmt.Sprintf("[%s] folder '%s' renamed to '%s'", orgName, oldName, newName)
+        } else if newName != "" {
+            enrichedMsg = fmt.Sprintf("[%s] folder renamed to %s", orgName, newName)
+        } else {
+            enrichedMsg = fmt.Sprintf("[%s] folder renamed", orgName)
+        }
+		
 	case "ORGA_RENAMED":
 		oldName, _ := data["old_name"].(string)
 		if oldName == "" {

--- a/backend/storage/internal/service/service.go
+++ b/backend/storage/internal/service/service.go
@@ -483,7 +483,7 @@ func (s *storageService) UpdateFolder(userID uuid.UUID, folderID uuid.UUID, newN
 	}
 
 	if newName != nil && *newName != oldName {
-		_ = s.publisher.PublishFolderRenamed(context.Background(), folder)
+		_ = s.publisher.PublishFolderRenamed(context.Background(), folder, userID)
 	}
 
 	if newParentID != nil {

--- a/backend/storage/internal/service/service.go
+++ b/backend/storage/internal/service/service.go
@@ -196,7 +196,7 @@ func (s *storageService) FinalizeUpload(userID uuid.UUID, objectID uuid.UUID, na
 	}
 
 	// _ because we ignore the return value of this call (fire-and-forget event)
-	_ = s.publisher.PublishFileUploaded(context.Background(), file)
+	_ = s.publisher.PublishFileUploaded(context.Background(), file, userID)
 
 	return file.ID, nil
 }
@@ -266,7 +266,7 @@ func (s *storageService) DeleteFile(ctx context.Context, userID uuid.UUID, fileI
 		return err
 	}
 
-	_ = s.publisher.PublishFileDeleted(context.Background(), file)
+	_ = s.publisher.PublishFileDeleted(context.Background(), file, userID)
 
 	return nil
 }
@@ -306,7 +306,7 @@ func (s *storageService) MoveFile(userID uuid.UUID, fileID uuid.UUID, folderID *
 		return ErrNotFound
 	}
 
-	_ = s.publisher.PublishFileMoved(context.Background(), file, folderID)
+	_ = s.publisher.PublishFileMoved(context.Background(), file, folderID, userID)
 
 	return nil
 }
@@ -360,7 +360,7 @@ func (s *storageService) CreateFolder(userID uuid.UUID, name string, parentID *u
 		return uuid.Nil, err
 	}
 
-	_ = s.publisher.PublishFolderCreated(context.Background(), &folder)
+	_ = s.publisher.PublishFolderCreated(context.Background(), &folder, userID)
 	return folder.ID, nil
 }
 
@@ -394,7 +394,7 @@ func (s *storageService) DeleteFolder(userID uuid.UUID, folderID uuid.UUID) erro
 		return err
 	}
 
-	_ = s.publisher.PublishFolderDeleted(context.Background(), folder)
+	_ = s.publisher.PublishFolderDeleted(context.Background(), folder, userID)
 	return nil
 }
 
@@ -488,7 +488,7 @@ func (s *storageService) UpdateFolder(userID uuid.UUID, folderID uuid.UUID, newN
 
 	if newParentID != nil {
 		if !uuidPtrEqual(oldParentID, *newParentID) {
-			_ = s.publisher.PublishFolderMoved(context.Background(), folder, oldParentID, *newParentID)
+			_ = s.publisher.PublishFolderMoved(context.Background(), folder, oldParentID, *newParentID, userID)
 		}
 	}
 
@@ -795,7 +795,7 @@ func (s *storageService) FinalizeMultipartUpload(ctx context.Context, userID uui
 		return uuid.Nil, err
 	}
 
-	_ = s.publisher.PublishFileUploaded(ctx, file)
+	_ = s.publisher.PublishFileUploaded(ctx, file, userID)
 	return file.ID, nil
 }
 

--- a/backend/storage/internal/service/service.go
+++ b/backend/storage/internal/service/service.go
@@ -483,7 +483,7 @@ func (s *storageService) UpdateFolder(userID uuid.UUID, folderID uuid.UUID, newN
 	}
 
 	if newName != nil && *newName != oldName {
-		_ = s.publisher.PublishFolderRenamed(context.Background(), folder, userID)
+		_ = s.publisher.PublishFolderRenamed(context.Background(), folder, userID, oldName)
 	}
 
 	if newParentID != nil {

--- a/backend/storage/internal/workers/events.go
+++ b/backend/storage/internal/workers/events.go
@@ -38,7 +38,7 @@ type FileUploadedPayload struct {
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
 	Name		string		`json:"name"`
 	FileSize	int64		`json:"file_size"`
-	ActorID  uuid.UUID  `json:"actor_id"`
+	ActorID  	uuid.UUID   `json:"actor_id"`
 }
 
 type FileDeletedPayload struct {
@@ -46,7 +46,7 @@ type FileDeletedPayload struct {
 	FolderID	*uuid.UUID	`json:"folder_id,omitempty"`
 	OwnerID		uuid.UUID	`json:"owner_id"`
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
-	ActorID  uuid.UUID  `json:"actor_id"`
+	ActorID  	uuid.UUID   `json:"actor_id"`
 }
 
 type FileMovedPayload struct {
@@ -55,7 +55,7 @@ type FileMovedPayload struct {
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
 	OldFolderID	*uuid.UUID	`json:"old_folder_id,omitempty"`
 	NewFolderID	*uuid.UUID	`json:"new_folder_id,omitempty"`
-	ActorID  uuid.UUID  `json:"actor_id"`
+	ActorID  	uuid.UUID   `json:"actor_id"`
 }
 
 type FolderCreatedPayload struct {
@@ -64,7 +64,7 @@ type FolderCreatedPayload struct {
 	OwnerID		uuid.UUID	`json:"owner_id"`
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
 	Name		string		`json:"name"`
-	ActorID  uuid.UUID  `json:"actor_id"`
+	ActorID  	uuid.UUID  `json:"actor_id"`
 }
 
 type FolderDeletedPayload struct {
@@ -72,7 +72,8 @@ type FolderDeletedPayload struct {
 	ParentID	*uuid.UUID	`json:"parent_id,omitempty"`
 	OwnerID		uuid.UUID	`json:"owner_id"`
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
-	ActorID  uuid.UUID  `json:"actor_id"`
+	ActorID  	uuid.UUID   `json:"actor_id"`
+	Name     	string      `json:"name"`
 }
 
 type FolderMovedPayload struct {
@@ -81,14 +82,15 @@ type FolderMovedPayload struct {
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
 	OldParentID	*uuid.UUID	`json:"old_parent_id,omitempty"`
 	NewParentID	*uuid.UUID	`json:"new_parent_id,omitempty"`
-	ActorID  uuid.UUID  `json:"actor_id"`
+	ActorID  	uuid.UUID   `json:"actor_id"`
 }
 
 type FolderRenamedPayload struct {
 	FolderID	uuid.UUID	`json:"folder_id"`
 	ParentID	*uuid.UUID	`json:"parent_id,omitempty"`
 	OwnerID		uuid.UUID	`json:"owner_id"`
-	ActorID  	uuid.UUID  `json:"actor_id"`
+	ActorID  	uuid.UUID   `json:"actor_id"`
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
 	NewName		string		`json:"new_name"`
+	OldName  	string      `json:"old_name"`
 }

--- a/backend/storage/internal/workers/events.go
+++ b/backend/storage/internal/workers/events.go
@@ -38,6 +38,7 @@ type FileUploadedPayload struct {
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
 	Name		string		`json:"name"`
 	FileSize	int64		`json:"file_size"`
+	ActorID  uuid.UUID  `json:"actor_id"`
 }
 
 type FileDeletedPayload struct {
@@ -45,6 +46,7 @@ type FileDeletedPayload struct {
 	FolderID	*uuid.UUID	`json:"folder_id,omitempty"`
 	OwnerID		uuid.UUID	`json:"owner_id"`
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
+	ActorID  uuid.UUID  `json:"actor_id"`
 }
 
 type FileMovedPayload struct {
@@ -53,6 +55,7 @@ type FileMovedPayload struct {
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
 	OldFolderID	*uuid.UUID	`json:"old_folder_id,omitempty"`
 	NewFolderID	*uuid.UUID	`json:"new_folder_id,omitempty"`
+	ActorID  uuid.UUID  `json:"actor_id"`
 }
 
 type FolderCreatedPayload struct {
@@ -61,6 +64,7 @@ type FolderCreatedPayload struct {
 	OwnerID		uuid.UUID	`json:"owner_id"`
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
 	Name		string		`json:"name"`
+	ActorID  uuid.UUID  `json:"actor_id"`
 }
 
 type FolderDeletedPayload struct {
@@ -68,6 +72,7 @@ type FolderDeletedPayload struct {
 	ParentID	*uuid.UUID	`json:"parent_id,omitempty"`
 	OwnerID		uuid.UUID	`json:"owner_id"`
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
+	ActorID  uuid.UUID  `json:"actor_id"`
 }
 
 type FolderMovedPayload struct {
@@ -76,6 +81,7 @@ type FolderMovedPayload struct {
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
 	OldParentID	*uuid.UUID	`json:"old_parent_id,omitempty"`
 	NewParentID	*uuid.UUID	`json:"new_parent_id,omitempty"`
+	ActorID  uuid.UUID  `json:"actor_id"`
 }
 
 type FolderRenamedPayload struct {

--- a/backend/storage/internal/workers/events.go
+++ b/backend/storage/internal/workers/events.go
@@ -82,6 +82,7 @@ type FolderRenamedPayload struct {
 	FolderID	uuid.UUID	`json:"folder_id"`
 	ParentID	*uuid.UUID	`json:"parent_id,omitempty"`
 	OwnerID		uuid.UUID	`json:"owner_id"`
+	ActorID  	uuid.UUID  `json:"actor_id"`
 	OrgID		*uuid.UUID	`json:"org_id,omitempty"`
 	NewName		string		`json:"new_name"`
 }

--- a/backend/storage/internal/workers/publisher.go
+++ b/backend/storage/internal/workers/publisher.go
@@ -130,6 +130,7 @@ func (p *EventPublisher) PublishFolderDeleted(ctx context.Context, folder *files
 		OwnerID:	folder.OwnerUserID,
 		OrgID:		folder.OrgID,
 		ActorID:    actorID,
+		Name:       folder.Name,
 	}
 
 	event := WSEvent{
@@ -149,7 +150,7 @@ func (p *EventPublisher) PublishFolderMoved(ctx context.Context, folder *files.F
 		OrgID:			folder.OrgID,
 		OldParentID:	oldParentID,
 		NewParentID:	newParentID,
-		ActorID:    actorID,
+		ActorID:    	actorID,
 	}
 
 	event := WSEvent{
@@ -161,7 +162,7 @@ func (p *EventPublisher) PublishFolderMoved(ctx context.Context, folder *files.F
 	return p.publish(ctx, folder.OwnerUserID, folder.OrgID, event)
 }
 
-func (p *EventPublisher) PublishFolderRenamed(ctx context.Context, folder *files.Folder, actorID uuid.UUID) error {
+func (p *EventPublisher) PublishFolderRenamed(ctx context.Context, folder *files.Folder, actorID uuid.UUID, oldName string) error {
 
 	payload := FolderRenamedPayload{
 		FolderID:		folder.ID,
@@ -170,6 +171,7 @@ func (p *EventPublisher) PublishFolderRenamed(ctx context.Context, folder *files
 		ActorID:        actorID,
 		OrgID:			folder.OrgID,
 		NewName:		folder.Name,
+		OldName:        oldName,
 	}
 
 	event := WSEvent{

--- a/backend/storage/internal/workers/publisher.go
+++ b/backend/storage/internal/workers/publisher.go
@@ -155,12 +155,13 @@ func (p *EventPublisher) PublishFolderMoved(ctx context.Context, folder *files.F
 	return p.publish(ctx, folder.OwnerUserID, folder.OrgID, event)
 }
 
-func (p *EventPublisher) PublishFolderRenamed(ctx context.Context, folder *files.Folder) error {
+func (p *EventPublisher) PublishFolderRenamed(ctx context.Context, folder *files.Folder, actorID uuid.UUID) error {
 
 	payload := FolderRenamedPayload{
 		FolderID:		folder.ID,
 		ParentID:		folder.ParentID,
 		OwnerID:		folder.OwnerUserID,
+		ActorID:        actorID,
 		OrgID:			folder.OrgID,
 		NewName:		folder.Name,
 	}
@@ -171,7 +172,7 @@ func (p *EventPublisher) PublishFolderRenamed(ctx context.Context, folder *files
 		Data:		payload,
 	}
 
-	return p.publish(ctx, folder.OwnerUserID, folder.OrgID, event)
+	return p.publish(ctx, actorID, folder.OrgID, event)
 }
 
 func (p *EventPublisher) PublishFileOrphaned(ctx context.Context, fileID uuid.UUID, minioObjectKey uuid.UUID, ownerID uuid.UUID) error {

--- a/backend/storage/internal/workers/publisher.go
+++ b/backend/storage/internal/workers/publisher.go
@@ -40,7 +40,7 @@ func (p *EventPublisher) publish(ctx context.Context, ownerID uuid.UUID, orgID *
 	return nil
 }
 
-func (p *EventPublisher) PublishFileUploaded(ctx context.Context, file *files.File) error {
+func (p *EventPublisher) PublishFileUploaded(ctx context.Context, file *files.File, actorID uuid.UUID) error {
 
 	payload := FileUploadedPayload{
 		FileID:		file.ID,
@@ -49,6 +49,7 @@ func (p *EventPublisher) PublishFileUploaded(ctx context.Context, file *files.Fi
 		OrgID:		file.OrgID,
 		Name:		file.Name,
 		FileSize:	file.FileSize,
+		ActorID:    actorID,
 	}
 
 	event := WSEvent{
@@ -60,13 +61,14 @@ func (p *EventPublisher) PublishFileUploaded(ctx context.Context, file *files.Fi
 	return p.publish(ctx, file.OwnerUserID, file.OrgID, event)
 }
 
-func (p *EventPublisher) PublishFileDeleted(ctx context.Context, file *files.File) error {
+func (p *EventPublisher) PublishFileDeleted(ctx context.Context, file *files.File, actorID uuid.UUID) error {
 
 	payload := FileDeletedPayload{
 		FileID:		file.ID,
 		FolderID:	file.FolderID,
 		OwnerID:	file.OwnerUserID,
 		OrgID:		file.OrgID,
+		ActorID:    actorID,
 	}
 
 	event := WSEvent{
@@ -80,7 +82,7 @@ func (p *EventPublisher) PublishFileDeleted(ctx context.Context, file *files.Fil
 
 
 // expects file.FolderID to still hold the OldFolderID at call time
-func (p *EventPublisher) PublishFileMoved(ctx context.Context, file *files.File, newFolderID *uuid.UUID) error {
+func (p *EventPublisher) PublishFileMoved(ctx context.Context, file *files.File, newFolderID *uuid.UUID, actorID uuid.UUID) error {
 
 	payload := FileMovedPayload{
 		FileID:			file.ID,
@@ -88,6 +90,7 @@ func (p *EventPublisher) PublishFileMoved(ctx context.Context, file *files.File,
 		OrgID:			file.OrgID,
 		OldFolderID:	file.FolderID,
 		NewFolderID:	newFolderID,
+		ActorID:    	actorID,
 	}
 
 	event := WSEvent{
@@ -99,7 +102,7 @@ func (p *EventPublisher) PublishFileMoved(ctx context.Context, file *files.File,
 	return p.publish(ctx, file.OwnerUserID, file.OrgID, event)
 }
 
-func (p *EventPublisher) PublishFolderCreated(ctx context.Context, folder *files.Folder) error {
+func (p *EventPublisher) PublishFolderCreated(ctx context.Context, folder *files.Folder, actorID uuid.UUID) error {
 
 	payload := FolderCreatedPayload{
 		FolderID:	folder.ID,
@@ -107,6 +110,7 @@ func (p *EventPublisher) PublishFolderCreated(ctx context.Context, folder *files
 		OwnerID:	folder.OwnerUserID,
 		OrgID:		folder.OrgID,
 		Name:		folder.Name,
+		ActorID:    actorID,
 	}
 
 	event := WSEvent{
@@ -118,13 +122,14 @@ func (p *EventPublisher) PublishFolderCreated(ctx context.Context, folder *files
 	return p.publish(ctx, folder.OwnerUserID, folder.OrgID, event)
 }
 
-func (p *EventPublisher) PublishFolderDeleted(ctx context.Context, folder *files.Folder) error {
+func (p *EventPublisher) PublishFolderDeleted(ctx context.Context, folder *files.Folder, actorID uuid.UUID) error {
 
 	payload := FolderDeletedPayload{
 		FolderID:	folder.ID,
 		ParentID:	folder.ParentID,
 		OwnerID:	folder.OwnerUserID,
 		OrgID:		folder.OrgID,
+		ActorID:    actorID,
 	}
 
 	event := WSEvent{
@@ -136,7 +141,7 @@ func (p *EventPublisher) PublishFolderDeleted(ctx context.Context, folder *files
 	return p.publish(ctx, folder.OwnerUserID, folder.OrgID, event)
 }
 
-func (p *EventPublisher) PublishFolderMoved(ctx context.Context, folder *files.Folder, oldParentID *uuid.UUID, newParentID *uuid.UUID) error {
+func (p *EventPublisher) PublishFolderMoved(ctx context.Context, folder *files.Folder, oldParentID *uuid.UUID, newParentID *uuid.UUID, actorID uuid.UUID) error {
 
 	payload := FolderMovedPayload{
 		FolderID:		folder.ID,
@@ -144,6 +149,7 @@ func (p *EventPublisher) PublishFolderMoved(ctx context.Context, folder *files.F
 		OrgID:			folder.OrgID,
 		OldParentID:	oldParentID,
 		NewParentID:	newParentID,
+		ActorID:    actorID,
 	}
 
 	event := WSEvent{

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -106,8 +106,9 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         const isActorMe = currentUserIdRef.current && actorId && currentUserIdRef.current.toLowerCase() === actorId.toLowerCase();
 
         const isTechnicalEvent = eventType === "USER_ONLINE" || eventType === "USER_OFFLINE" || eventType === "USER_PROFILE_UPDATED";
+        const shouldNotify = eventType !== "file_moved" && eventType !== "folder_moved";
 
-        if (!isActorMe && !isTechnicalEvent) {
+        if (!isActorMe && !isTechnicalEvent && shouldNotify) {
           const newNotification: NotificationItem = {
             id: crypto.randomUUID(),
             event: eventType,

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -102,7 +102,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         const payload = JSON.parse(event.data);
 
         const eventType = payload.event || payload.type || "UNKNOWN";
-        const actorId = payload.data?.owner_id || payload.data?.user_id;
+        const actorId = payload.data?.actor_id || payload.data?.user_id || payload.data?.owner_id;
         const isActorMe = currentUserIdRef.current && actorId && currentUserIdRef.current.toLowerCase() === actorId.toLowerCase();
 
         const isTechnicalEvent = eventType === "USER_ONLINE" || eventType === "USER_OFFLINE" || eventType === "USER_PROFILE_UPDATED";

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -106,9 +106,8 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         const isActorMe = currentUserIdRef.current && actorId && currentUserIdRef.current.toLowerCase() === actorId.toLowerCase();
 
         const isTechnicalEvent = eventType === "USER_ONLINE" || eventType === "USER_OFFLINE" || eventType === "USER_PROFILE_UPDATED";
-        const shouldNotify = eventType !== "file_moved" && eventType !== "folder_moved";
 
-        if (!isActorMe && !isTechnicalEvent && shouldNotify) {
+        if (!isActorMe && !isTechnicalEvent) {
           const newNotification: NotificationItem = {
             id: crypto.randomUUID(),
             event: eventType,


### PR DESCRIPTION
This PR resolves a user experience bug where the creator/owner of a file or folder was not receiving any visual notifications (Toasts / Dropdown entries) when another member of the organization performed an action (deletion, renaming, moving) on their items.

#### Backend (`storage` & `orga`)

* **Payloads & Publisher**: Added the `ActorID` field (`actor_id` in JSON) across all storage event structures (`FileUploaded`, `FileDeleted`, `FileMoved`, `FolderCreated`, `FolderDeleted`, `FolderMoved`, `FolderRenamed`).

* **WebSocket Hub (`ws_handler.go`)**: Enhanced and fortified server-generated messages (`folder_created`, `folder_deleted`, `folder_renamed`, `folder_moved`) with reliable fallbacks (protection) in case item names are missing from the payload.



#### Frontend (`orga-ui`)

* **`NotificationContext.tsx`**: Updated the action author detection to check the new `actor_id` field with the highest priority 
* **Filter Logic**: The deduplication filter now accurately targets the real actor, finally allowing resource owners to view live alerts when someone else interacts with their folders/files.