### PR TITLE
fix: preview

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,7 +15,9 @@
                 "qrcode.react": "^4.2.0",
                 "react": "^18.3.1",
                 "react-dom": "^18.3.1",
+                "react-markdown": "^9.0.1",
                 "react-router-dom": "^7.13.2",
+                "remark-gfm": "^4.0.0",
                 "zod": "^4.4.3"
             },
             "devDependencies": {
@@ -1615,11 +1617,52 @@
                 "@babel/types": "^7.28.2"
             }
         },
+        "node_modules/@types/debug": {
+            "version": "4.1.13",
+            "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+            "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/ms": "*"
+            }
+        },
         "node_modules/@types/estree": {
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
             "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
-            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/estree-jsx": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+            "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "*"
+            }
+        },
+        "node_modules/@types/hast": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+            "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
+        "node_modules/@types/mdast": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+            "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "*"
+            }
+        },
+        "node_modules/@types/ms": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+            "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
             "license": "MIT"
         },
         "node_modules/@types/node": {
@@ -1636,14 +1679,12 @@
             "version": "15.7.15",
             "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
             "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/@types/react": {
             "version": "18.3.29",
             "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.29.tgz",
             "integrity": "sha512-ch0qJdr2JY0r04NXSprbK6TXOgnaJ1Tz23fm5W+z0/CBah6BSBc3n96h7K9GOtwh0HrilNWHIBzE1Ko4Dcw/Wg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/prop-types": "*",
@@ -1660,11 +1701,16 @@
                 "@types/react": "^18.0.0"
             }
         },
+        "node_modules/@types/unist": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+            "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+            "license": "MIT"
+        },
         "node_modules/@ungap/structured-clone": {
             "version": "1.3.1",
             "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
             "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
-            "dev": true,
             "license": "ISC"
         },
         "node_modules/@vitejs/plugin-react": {
@@ -1798,6 +1844,16 @@
                 "postcss": "^8.1.0"
             }
         },
+        "node_modules/bail": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+            "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1894,6 +1950,16 @@
             ],
             "license": "CC-BY-4.0"
         },
+        "node_modules/ccount": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+            "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1909,6 +1975,46 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/character-entities": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+            "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/character-entities-html4": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+            "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/character-entities-legacy": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+            "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/character-reference-invalid": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+            "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/color-convert": {
@@ -1930,6 +2036,16 @@
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/comma-separated-tokens": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+            "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
@@ -1983,7 +2099,6 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/debug": {
@@ -2003,12 +2118,34 @@
                 }
             }
         },
+        "node_modules/decode-named-character-reference": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+            "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+            "license": "MIT",
+            "dependencies": {
+                "character-entities": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/deep-is": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/dequal": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+            "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
         },
         "node_modules/detect-libc": {
             "version": "2.1.2",
@@ -2018,6 +2155,19 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/devlop": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+            "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+            "license": "MIT",
+            "dependencies": {
+                "dequal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/doctrine": {
@@ -2257,6 +2407,16 @@
                 "node": ">=4.0"
             }
         },
+        "node_modules/estree-util-is-identifier-name": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+            "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/esutils": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2266,6 +2426,12 @@
             "engines": {
                 "node": ">=0.10.0"
             }
+        },
+        "node_modules/extend": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "license": "MIT"
         },
         "node_modules/fast-deep-equal": {
             "version": "3.1.3",
@@ -2516,6 +2682,56 @@
                 "node": ">=8"
             }
         },
+        "node_modules/hast-util-to-jsx-runtime": {
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+            "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0",
+                "@types/hast": "^3.0.0",
+                "@types/unist": "^3.0.0",
+                "comma-separated-tokens": "^2.0.0",
+                "devlop": "^1.0.0",
+                "estree-util-is-identifier-name": "^3.0.0",
+                "hast-util-whitespace": "^3.0.0",
+                "mdast-util-mdx-expression": "^2.0.0",
+                "mdast-util-mdx-jsx": "^3.0.0",
+                "mdast-util-mdxjs-esm": "^2.0.0",
+                "property-information": "^7.0.0",
+                "space-separated-tokens": "^2.0.0",
+                "style-to-js": "^1.0.0",
+                "unist-util-position": "^5.0.0",
+                "vfile-message": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/hast-util-whitespace": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+            "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/html-url-attributes": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+            "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/ieee754": {
             "version": "1.2.1",
             "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
@@ -2592,6 +2808,46 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/inline-style-parser": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+            "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+            "license": "MIT"
+        },
+        "node_modules/is-alphabetical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+            "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/is-alphanumerical": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+            "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+            "license": "MIT",
+            "dependencies": {
+                "is-alphabetical": "^2.0.0",
+                "is-decimal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/is-decimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+            "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2615,6 +2871,16 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-hexadecimal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+            "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/is-path-inside": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
@@ -2623,6 +2889,18 @@
             "license": "MIT",
             "engines": {
                 "node": ">=8"
+            }
+        },
+        "node_modules/is-plain-obj": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+            "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/isexe": {
@@ -3016,6 +3294,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/longest-streak": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+            "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/loose-envify": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -3056,6 +3344,861 @@
             "dependencies": {
                 "@jridgewell/sourcemap-codec": "^1.5.5"
             }
+        },
+        "node_modules/markdown-table": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+            "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+            "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "escape-string-regexp": "^5.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+            "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/mdast-util-from-markdown": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+            "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark": "^4.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unist-util-stringify-position": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+            "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+            "license": "MIT",
+            "dependencies": {
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-gfm-autolink-literal": "^2.0.0",
+                "mdast-util-gfm-footnote": "^2.0.0",
+                "mdast-util-gfm-strikethrough": "^2.0.0",
+                "mdast-util-gfm-table": "^2.0.0",
+                "mdast-util-gfm-task-list-item": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-autolink-literal": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+            "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "ccount": "^2.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-find-and-replace": "^3.0.0",
+                "micromark-util-character": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-footnote": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.1.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-strikethrough": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+            "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-table": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+            "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "markdown-table": "^3.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-gfm-task-list-item": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+            "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-mdx-expression": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+            "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree-jsx": "^1.0.0",
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-mdx-jsx": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+            "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree-jsx": "^1.0.0",
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "ccount": "^2.0.0",
+                "devlop": "^1.1.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "parse-entities": "^4.0.0",
+                "stringify-entities": "^4.0.0",
+                "unist-util-stringify-position": "^4.0.0",
+                "vfile-message": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-mdxjs-esm": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+            "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree-jsx": "^1.0.0",
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "mdast-util-to-markdown": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-phrasing": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+            "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-hast": {
+            "version": "13.2.1",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+            "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "@ungap/structured-clone": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "trim-lines": "^3.0.0",
+                "unist-util-position": "^5.0.0",
+                "unist-util-visit": "^5.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-markdown": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+            "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "@types/unist": "^3.0.0",
+                "longest-streak": "^3.0.0",
+                "mdast-util-phrasing": "^4.0.0",
+                "mdast-util-to-string": "^4.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-decode-string": "^2.0.0",
+                "unist-util-visit": "^5.0.0",
+                "zwitch": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/mdast-util-to-string": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+            "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+            "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@types/debug": "^4.0.0",
+                "debug": "^4.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-core-commonmark": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+            "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "devlop": "^1.0.0",
+                "micromark-factory-destination": "^2.0.0",
+                "micromark-factory-label": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-factory-title": "^2.0.0",
+                "micromark-factory-whitespace": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-html-tag-name": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-subtokenize": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-extension-gfm": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+            "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+            "license": "MIT",
+            "dependencies": {
+                "micromark-extension-gfm-autolink-literal": "^2.0.0",
+                "micromark-extension-gfm-footnote": "^2.0.0",
+                "micromark-extension-gfm-strikethrough": "^2.0.0",
+                "micromark-extension-gfm-table": "^2.0.0",
+                "micromark-extension-gfm-tagfilter": "^2.0.0",
+                "micromark-extension-gfm-task-list-item": "^2.0.0",
+                "micromark-util-combine-extensions": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-autolink-literal": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+            "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-footnote": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+            "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-core-commonmark": "^2.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-normalize-identifier": "^2.0.0",
+                "micromark-util-sanitize-uri": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-strikethrough": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+            "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-classify-character": "^2.0.0",
+                "micromark-util-resolve-all": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-table": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+            "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-tagfilter": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+            "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-extension-gfm-task-list-item": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+            "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/micromark-factory-destination": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+            "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-label": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+            "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-space": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+            "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-title": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+            "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-factory-whitespace": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+            "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-factory-space": "^2.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-character": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+            "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-chunked": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+            "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-classify-character": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+            "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-combine-extensions": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+            "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-numeric-character-reference": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+            "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-decode-string": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+            "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "decode-named-character-reference": "^1.0.0",
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-decode-numeric-character-reference": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-encode": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+            "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-html-tag-name": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+            "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-normalize-identifier": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+            "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-resolve-all": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+            "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-sanitize-uri": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+            "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "micromark-util-character": "^2.0.0",
+                "micromark-util-encode": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-subtokenize": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+            "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "devlop": "^1.0.0",
+                "micromark-util-chunked": "^2.0.0",
+                "micromark-util-symbol": "^2.0.0",
+                "micromark-util-types": "^2.0.0"
+            }
+        },
+        "node_modules/micromark-util-symbol": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+            "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
+        },
+        "node_modules/micromark-util-types": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+            "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+            "funding": [
+                {
+                    "type": "GitHub Sponsors",
+                    "url": "https://github.com/sponsors/unifiedjs"
+                },
+                {
+                    "type": "OpenCollective",
+                    "url": "https://opencollective.com/unified"
+                }
+            ],
+            "license": "MIT"
         },
         "node_modules/minimatch": {
             "version": "3.1.5",
@@ -3200,6 +4343,31 @@
                 "node": ">=6"
             }
         },
+        "node_modules/parse-entities": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+            "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^2.0.0",
+                "character-entities-legacy": "^3.0.0",
+                "character-reference-invalid": "^2.0.0",
+                "decode-named-character-reference": "^1.0.0",
+                "is-alphanumerical": "^2.0.0",
+                "is-decimal": "^2.0.0",
+                "is-hexadecimal": "^2.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/parse-entities/node_modules/@types/unist": {
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+            "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+            "license": "MIT"
+        },
         "node_modules/path-exists": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3283,6 +4451,16 @@
                 "node": ">= 0.8.0"
             }
         },
+        "node_modules/property-information": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+            "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/punycode": {
             "version": "2.3.1",
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3348,6 +4526,33 @@
                 "react": "^18.3.1"
             }
         },
+        "node_modules/react-markdown": {
+            "version": "9.1.0",
+            "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-9.1.0.tgz",
+            "integrity": "sha512-xaijuJB0kzGiUdG7nc2MOMDUDBWPyGAjZtUrow9XxUeua8IqeP+VlIfAZ3bphpcLTnSZXz6z9jcVC/TCwbfgdw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "devlop": "^1.0.0",
+                "hast-util-to-jsx-runtime": "^2.0.0",
+                "html-url-attributes": "^3.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "remark-parse": "^11.0.0",
+                "remark-rehype": "^11.0.0",
+                "unified": "^11.0.0",
+                "unist-util-visit": "^5.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            },
+            "peerDependencies": {
+                "@types/react": ">=18",
+                "react": ">=18"
+            }
+        },
         "node_modules/react-refresh": {
             "version": "0.17.0",
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -3394,6 +4599,72 @@
             "peerDependencies": {
                 "react": ">=18",
                 "react-dom": ">=18"
+            }
+        },
+        "node_modules/remark-gfm": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+            "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-gfm": "^3.0.0",
+                "micromark-extension-gfm": "^3.0.0",
+                "remark-parse": "^11.0.0",
+                "remark-stringify": "^11.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-parse": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+            "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-from-markdown": "^2.0.0",
+                "micromark-util-types": "^2.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-rehype": {
+            "version": "11.1.2",
+            "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+            "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/hast": "^3.0.0",
+                "@types/mdast": "^4.0.0",
+                "mdast-util-to-hast": "^13.0.0",
+                "unified": "^11.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/remark-stringify": {
+            "version": "11.0.0",
+            "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+            "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/mdast": "^4.0.0",
+                "mdast-util-to-markdown": "^2.0.0",
+                "unified": "^11.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/resolve-from": {
@@ -3561,6 +4832,30 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/space-separated-tokens": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+            "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/stringify-entities": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+            "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+            "license": "MIT",
+            "dependencies": {
+                "character-entities-html4": "^2.0.0",
+                "character-entities-legacy": "^3.0.0"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
         "node_modules/strip-ansi": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
@@ -3601,6 +4896,24 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/style-to-js": {
+            "version": "1.1.21",
+            "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+            "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+            "license": "MIT",
+            "dependencies": {
+                "style-to-object": "1.0.14"
+            }
+        },
+        "node_modules/style-to-object": {
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+            "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+            "license": "MIT",
+            "dependencies": {
+                "inline-style-parser": "0.2.7"
             }
         },
         "node_modules/supports-color": {
@@ -3660,6 +4973,26 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/trim-lines": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+            "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
+            }
+        },
+        "node_modules/trough": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+            "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         },
         "node_modules/tslib": {
@@ -3727,6 +5060,93 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/unified": {
+            "version": "11.0.5",
+            "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+            "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "bail": "^2.0.0",
+                "devlop": "^1.0.0",
+                "extend": "^3.0.0",
+                "is-plain-obj": "^4.0.0",
+                "trough": "^2.0.0",
+                "vfile": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-is": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+            "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-position": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+            "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-stringify-position": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+            "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-visit": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+            "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0",
+                "unist-util-visit-parents": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/unist-util-visit-parents": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+            "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-is": "^6.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
         "node_modules/update-browserslist-db": {
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -3766,6 +5186,34 @@
             "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
+            }
+        },
+        "node_modules/vfile": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+            "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "vfile-message": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
+            }
+        },
+        "node_modules/vfile-message": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+            "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/unist": "^3.0.0",
+                "unist-util-stringify-position": "^4.0.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/unified"
             }
         },
         "node_modules/vite": {
@@ -3888,6 +5336,16 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/colinhacks"
+            }
+        },
+        "node_modules/zwitch": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+            "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+            "license": "MIT",
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/wooorm"
             }
         }
     }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,9 @@
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^7.13.2",
-        "zod": "^4.4.3"
+        "zod": "^4.4.3",
+        "react-markdown": "^9.0.1",
+        "remark-gfm": "^4.0.0"
     },
     "devDependencies": {
         "@tailwindcss/postcss": "^4.2.2",

--- a/frontend/src/components/FileCard/index.tsx
+++ b/frontend/src/components/FileCard/index.tsx
@@ -1,17 +1,3 @@
-import {
-  File,
-  FileText,
-  FileImage,
-  FileVideo,
-  FileSpreadsheet,
-  FileCode,
-  FileArchive,
-  Download,
-  Move,
-  Trash2,
-  MoreVertical,
-  Eye
-} from "lucide-react";
 import { useState, useEffect, useRef } from "react";
 import styles from "./FileCard.module.css";
 import { ConfirmationModal } from "../ConfirmationModal";
@@ -20,6 +6,8 @@ import { useDecryptFilename } from "../../hooks/useDecryptFilename";
 import { useKeyCheck } from "../../hooks/useKeyCheck";
 import { FilePreviewModal } from "../FilePreviewModal";
 import { formatFileSize, getDecryptedSize } from "../../services/fileValidation.service";
+import { Download, Move, Trash2, MoreVertical, Eye } from "lucide-react";
+import { getFileVisual } from "../../config/fileIcon";
 
 interface FileCardProps {
   id: string;
@@ -33,68 +21,6 @@ interface FileCardProps {
   onDownload?: (id: string) => void;
   onMove?: (id: string, newParentId: string | null, name: string) => Promise<void>;
 }
-
-const getFileIconAndColor = (fileName: string) => {
-    const ext = fileName.split('.').pop()?.toLowerCase() || '';
-
-    if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'].includes(ext)) {
-        return {
-            Icon: FileImage,
-            color: "#ec4899",
-            bg: "rgba(236, 72, 153, 0.1)"
-        };
-    }
-
-    if (['mp4', 'webm', 'mov', 'avi', 'mkv', 'mpeg'].includes(ext)) {
-        return {
-            Icon: FileVideo,
-            color: "#8b5cf6",
-            bg: "rgba(139, 92, 246, 0.1)"
-        };
-    }
-    if (['pdf'].includes(ext)) {
-        return {
-            Icon: FileText,
-            color: "#ef4444",
-            bg: "rgba(239, 68, 68, 0.1)"
-        };
-    }
-    if (['xls', 'xlsx', 'csv', 'ods'].includes(ext)) {
-        return {
-            Icon: FileSpreadsheet,
-            color: "#10b981",
-            bg: "rgba(16, 185, 129, 0.1)"
-        };
-    }
-
-    if (['zip', 'rar', '7z', 'tar', 'gz'].includes(ext)) {
-        return {
-            Icon: FileArchive,
-            color: "#f59e0b",
-            bg: "rgba(245, 158, 11, 0.1)"
-        };
-    }
-    if (['json', 'js', 'ts', 'tsx', 'html', 'css', 'go', 'sh', 'yaml', 'yml'].includes(ext)) {
-        return {
-            Icon: FileCode,
-            color: "#06b6d4",
-            bg: "rgba(6, 182, 212, 0.1)"
-        };
-    }
-    if (['txt', 'md', 'rtf'].includes(ext)) {
-        return {
-            Icon: FileText,
-            color: "#3b82f6",
-            bg: "rgba(59, 130, 246, 0.1)"
-        };
-    }
-
-    return {
-        Icon: File,
-        color: "#865142",
-        bg: "rgba(134, 81, 66, 0.1)"
-    };
-};
 
 export function FileCard({ id, name, fileSize, orgId, owner_user_id, role, user_id, onDelete, onDownload, onMove }: FileCardProps) {
   const [showDeleteModal, setShowDeleteModal] = useState(false);
@@ -141,7 +67,7 @@ export function FileCard({ id, name, fileSize, orgId, owner_user_id, role, user_
     }
   }, [showMenu]);
 
-  const { Icon, color, bg } = getFileIconAndColor(displayName);
+  const { Icon, color, bg } = getFileVisual(displayName);
 
   return (
     <>
@@ -253,6 +179,7 @@ export function FileCard({ id, name, fileSize, orgId, owner_user_id, role, user_
           fileName={displayName}
           fileSize={fileSize}
           orgId={orgId}
+          onDownload={() => handleDownloadClick()}
         />
       )}
     </>

--- a/frontend/src/components/FilePreviewModal/FilePreviewModal.module.css
+++ b/frontend/src/components/FilePreviewModal/FilePreviewModal.module.css
@@ -359,6 +359,100 @@
     transform: scale(0.97);
 }
 
+.mediaWrapper {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    box-sizing: border-box;
+}
+
+.audioPlayer {
+    width: 80%;
+    max-width: 560px;
+}
+
+.videoPlayer {
+    max-width: 100%;
+    max-height: 100%;
+    border-radius: 8px;
+    background: #000;
+}
+
+.markdownWrapper {
+    width: 100%;
+    height: 100%;
+    overflow: auto;
+    background: var(--color-white, #fff);
+    box-sizing: border-box;
+}
+
+.markdownBody {
+    max-width: 820px;
+    margin: 0 auto;
+    padding: 32px 40px;
+    line-height: 1.65;
+    color: #1e293b;
+    font-size: 15px;
+}
+
+.markdownBody h1, .markdownBody h2, .markdownBody h3 {
+    margin: 1.4em 0 0.6em;
+    font-weight: 600;
+}
+
+.markdownBody h1 {
+    font-size: 1.8em;
+    border-bottom: 1px solid #e2e8f0;
+    padding-bottom: .3em;
+}
+
+.markdownBody h2 {
+    font-size: 1.4em;
+    border-bottom: 1px solid #e2e8f0;
+    padding-bottom: .3em;
+}
+
+.markdownBody p {
+    margin: 0.8em 0;
+}
+
+.markdownBody pre {
+    background: #0f172a; color: #e2e8f0; padding: 16px;
+    border-radius: 8px; overflow-x: auto;
+    font-family: 'Fira Code', 'Courier New', monospace; font-size: 13px;
+}
+
+.markdownBody code {
+    background: rgba(15, 23, 42, 0.06); padding: 2px 5px;
+    border-radius: 4px; font-family: 'Fira Code', monospace; font-size: .9em;
+}
+
+.markdownBody pre code {
+    background: none;
+    padding: 0;
+}
+
+.markdownBody table {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 1em 0;
+}
+
+.markdownBody th, .markdownBody td {
+    border: 1px solid #e2e8f0;
+    padding: 8px 12px;
+}
+
+.markdownBody blockquote {
+    border-left: 4px solid #cbd5e1;
+    margin: 1em 0;
+    padding-left: 16px;
+    color: #64748b;
+}
+
 @keyframes fadeIn {
     from { opacity: 0; }
     to { opacity: 1; }
@@ -394,7 +488,7 @@
         padding: 12px 16px;
     }
     .actionText {
-        display: none; 
+        display: none;
     }
     .actionButton {
         padding: 8px;

--- a/frontend/src/components/FilePreviewModal/FilePreviewModal.module.css
+++ b/frontend/src/components/FilePreviewModal/FilePreviewModal.module.css
@@ -453,6 +453,12 @@
     color: #64748b;
 }
 
+.errorActions {
+    display: flex;
+    gap: 12px;
+    margin-top: 8px;
+}
+
 @keyframes fadeIn {
     from { opacity: 0; }
     to { opacity: 1; }

--- a/frontend/src/components/FilePreviewModal/index.tsx
+++ b/frontend/src/components/FilePreviewModal/index.tsx
@@ -4,17 +4,16 @@ import {
     Download,
     AlertTriangle,
     Loader2,
-    FileText,
-    FileImage,
-    FileCode,
     File,
     FileVideo,
-    FileSpreadsheet,
-    FileArchive
 } from "lucide-react";
 import { useE2EEPreview } from "../../hooks/useE2EEPreview";
 import styles from "./FilePreviewModal.module.css";
 import { formatFileSize, getDecryptedSize } from "../../services/fileValidation.service";
+import ReactMarkdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
+import { resolvePreview, MAX_VIDEO_PREVIEW_BYTES } from '../../config/previewType';
+import { getFileVisual } from "../../config/fileIcon";
 
 interface FilePreviewModalProps {
     isOpen: boolean;
@@ -23,34 +22,8 @@ interface FilePreviewModalProps {
     fileName: string;
     fileSize: number;
     orgId?: string;
+    onDownload?: () => void;
 }
-
-const getFileIconAndColor = (fileName: string) => {
-    const ext = fileName.split('.').pop()?.toLowerCase() || '';
-
-    if (['jpg', 'jpeg', 'png', 'gif', 'webp', 'bmp', 'svg'].includes(ext)) {
-        return { Icon: FileImage, color: "#ec4899" };
-    }
-    if (['mp4', 'webm', 'mov', 'avi', 'mkv', 'mpeg'].includes(ext)) {
-        return { Icon: FileVideo, color: "#8b5cf6" };
-    }
-    if (['pdf'].includes(ext)) {
-        return { Icon: FileText, color: "#ef4444" };
-    }
-    if (['xls', 'xlsx', 'csv', 'ods'].includes(ext)) {
-        return { Icon: FileSpreadsheet, color: "#10b981" };
-    }
-    if (['zip', 'rar', '7z', 'tar', 'gz'].includes(ext)) {
-        return { Icon: FileArchive, color: "#f59e0b" };
-    }
-    if (['json', 'js', 'ts', 'tsx', 'html', 'css', 'go', 'sh', 'yaml', 'yml'].includes(ext)) {
-        return { Icon: FileCode, color: "#06b6d4" };
-    }
-    if (['txt', 'md', 'rtf'].includes(ext)) {
-        return { Icon: FileText, color: "#3b82f6" };
-    }
-    return { Icon: File, color: "#865142" };
-};
 
 export function FilePreviewModal({
     isOpen,
@@ -58,7 +31,8 @@ export function FilePreviewModal({
     fileId,
     fileName,
     fileSize,
-    orgId
+    orgId,
+    onDownload
 }: FilePreviewModalProps) {
     const { decryptForPreview, downloadStatus, isDownloading, downloadError } = useE2EEPreview();
     const [blob, setBlob] = useState<Blob | null>(null);
@@ -83,6 +57,10 @@ export function FilePreviewModal({
         const controller = new AbortController();
 
         const loadPreview = async () => {
+            if (resolvePreview(fileName).kind === 'video'
+                && getDecryptedSize(fileSize) > MAX_VIDEO_PREVIEW_BYTES) {
+                return;
+            }
             try {
                 const result = await decryptForPreview(fileId, orgId, controller.signal);
                 if (result && isMounted) {
@@ -91,8 +69,8 @@ export function FilePreviewModal({
                     objectUrlRef.current = url;
                     setObjectUrl(url);
 
-                    const type = result.blob.type;
-                    if (type.startsWith("text/") || type === "application/json") {
+                    const { kind: resolvedKind } = resolvePreview(fileName);
+                    if (resolvedKind === 'text' || resolvedKind === 'code' || resolvedKind === 'markdown') {
                         setIsTextLoading(true);
                         try {
                             const text = await result.blob.text();
@@ -145,6 +123,11 @@ export function FilePreviewModal({
 
     if (!isOpen) return null;
 
+    const { kind } = resolvePreview(fileName);
+    const { Icon, color } = getFileVisual(fileName);
+    const decryptedSize = getDecryptedSize(fileSize);
+    const videoTooLarge = kind === 'video' && decryptedSize > MAX_VIDEO_PREVIEW_BYTES;
+
     const handleDownloadInstant = () => {
         if (!blob) return;
         const url = URL.createObjectURL(blob);
@@ -156,12 +139,6 @@ export function FilePreviewModal({
         document.body.removeChild(a);
         URL.revokeObjectURL(url);
     };
-
-    const isImage = blob?.type.startsWith("image/");
-    const isPDF = blob?.type === "application/pdf";
-    const isText = blob?.type.startsWith("text/") || blob?.type === "application/json";
-
-    const { Icon, color } = getFileIconAndColor(fileName);
 
     return (
         <>
@@ -217,23 +194,48 @@ export function FilePreviewModal({
                         </div>
                     )}
 
+                    {!isDownloading && !downloadError && videoTooLarge && (
+                        <div className={styles.fallbackContainer}>
+                            <FileVideo size={64} className={styles.fallbackIcon} />
+                            <h4 className={styles.fallbackTitle}>Video too large to preview</h4>
+                            <p className={styles.fallbackMessage}>
+                                This video is {formatFileSize(decryptedSize)}. In-browser preview is capped at{' '}
+                                {formatFileSize(MAX_VIDEO_PREVIEW_BYTES)} to keep memory usage safe.
+                                Downloading it streams directly to disk.
+                            </p>
+                            <button
+                                className={styles.fallbackDownloadButton}
+                                onClick={() => { onDownload?.(); onClose(); }}
+                            >
+                                <Download size={16} /> Download instead
+                            </button>
+                        </div>
+                    )}
                     {!isDownloading && !downloadError && blob && (
                         <div className={styles.previewContainer}>
-                            {isImage && objectUrl && (
+                            {kind === 'image' && objectUrl && (
                                 <div className={styles.imageWrapper}>
                                     <img src={objectUrl} alt={fileName} className={styles.previewImage} />
                                 </div>
                             )}
 
-                            {isPDF && objectUrl && (
-                                <iframe
-                                    src={`${objectUrl}#toolbar=1`}
-                                    className={styles.pdfViewer}
-                                    title={fileName}
-                                />
+                            {kind === 'pdf' && objectUrl && (
+                                <iframe src={`${objectUrl}#toolbar=1`} className={styles.pdfViewer} title={fileName} />
                             )}
 
-                            {isText && (
+                            {kind === 'audio' && objectUrl && (
+                                <div className={styles.mediaWrapper}>
+                                    <audio controls src={objectUrl} className={styles.audioPlayer} />
+                                </div>
+                            )}
+
+                            {kind === 'video' && objectUrl && (
+                                <div className={styles.mediaWrapper}>
+                                    <video controls src={objectUrl} className={styles.videoPlayer} />
+                                </div>
+                            )}
+
+                            {(kind === 'text' || kind === 'code') && (
                                 <div className={styles.textWrapper}>
                                     {isTextLoading ? (
                                         <div className={styles.textLoadingContainer}>
@@ -241,14 +243,27 @@ export function FilePreviewModal({
                                             <p className={styles.textStatus}>Reading text content...</p>
                                         </div>
                                     ) : (
-                                        <pre className={styles.textPre}>
-                                            <code>{textContent}</code>
-                                        </pre>
+                                        <pre className={styles.textPre}><code>{textContent}</code></pre>
                                     )}
                                 </div>
                             )}
 
-                            {!isImage && !isPDF && !isText && (
+                            {kind === 'markdown' && (
+                                <div className={styles.markdownWrapper}>
+                                    {isTextLoading ? (
+                                        <div className={styles.textLoadingContainer}>
+                                            <Loader2 className={styles.textSpinner} size={24} />
+                                            <p className={styles.textStatus}>Reading content...</p>
+                                        </div>
+                                    ) : (
+                                        <div className={styles.markdownBody}>
+                                            <ReactMarkdown remarkPlugins={[remarkGfm]}>{textContent}</ReactMarkdown>
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+
+                            {kind === 'unknown' && (
                                 <div className={styles.fallbackContainer}>
                                     <File size={64} className={styles.fallbackIcon} />
                                     <h4 className={styles.fallbackTitle}>No Preview Available</h4>
@@ -256,8 +271,7 @@ export function FilePreviewModal({
                                         We don't support previewing {fileName.split('.').pop()?.toUpperCase() || 'this type of'} files directly.
                                     </p>
                                     <button className={styles.fallbackDownloadButton} onClick={handleDownloadInstant}>
-                                        <Download size={16} />
-                                        Download Decrypted File
+                                        <Download size={16} /> Download Decrypted File
                                     </button>
                                 </div>
                             )}

--- a/frontend/src/components/FilePreviewModal/index.tsx
+++ b/frontend/src/components/FilePreviewModal/index.tsx
@@ -69,7 +69,7 @@ export function FilePreviewModal({
                     objectUrlRef.current = url;
                     setObjectUrl(url);
 
-                    const { kind: resolvedKind } = resolvePreview(fileName);
+                    const { kind: resolvedKind } = resolvePreview(result.filename);
                     if (resolvedKind === 'text' || resolvedKind === 'code' || resolvedKind === 'markdown') {
                         setIsTextLoading(true);
                         try {

--- a/frontend/src/config/fileIcon.ts
+++ b/frontend/src/config/fileIcon.ts
@@ -1,0 +1,35 @@
+import type { ComponentType } from 'react';
+import { File, FileText, FileImage, FileVideo, FileAudio, FileCode, FileSpreadsheet, FileArchive } from 'lucide-react';
+import { resolvePreview, type PreviewKind } from './previewType';
+
+export interface FileVisual {
+	Icon: ComponentType<{ size?: number | string }>;
+	color: string;
+	bg: string;
+}
+
+const VISUALS: Record<PreviewKind, FileVisual> = {
+	image:    { Icon: FileImage, color: '#ec4899', bg: 'rgba(236, 72, 153, 0.1)' },
+	video:    { Icon: FileVideo, color: '#8b5cf6', bg: 'rgba(139, 92, 246, 0.1)' },
+	audio:    { Icon: FileAudio, color: '#f59e0b', bg: 'rgba(245, 158, 11, 0.1)' },
+	pdf:      { Icon: FileText,  color: '#ef4444', bg: 'rgba(239, 68, 68, 0.1)' },
+	code:     { Icon: FileCode,  color: '#06b6d4', bg: 'rgba(6, 182, 212, 0.1)' },
+	markdown: { Icon: FileText,  color: '#3b82f6', bg: 'rgba(59, 130, 246, 0.1)' },
+	text:     { Icon: FileText,  color: '#3b82f6', bg: 'rgba(59, 130, 246, 0.1)' },
+	unknown:  { Icon: File,      color: '#865142', bg: 'rgba(134, 81, 66, 0.1)' },
+};
+
+const SPREADSHEET: FileVisual = { Icon: FileSpreadsheet, color: '#10b981', bg: 'rgba(16, 185, 129, 0.1)' };
+const ARCHIVE: FileVisual = { Icon: FileArchive, color: '#f59e0b', bg: 'rgba(245, 158, 11, 0.1)' };
+
+export function getFileVisual(filename: string): FileVisual {
+
+	const { kind } = resolvePreview(filename);
+	if (kind !== 'unknown') return VISUALS[kind];
+
+	const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+	if (['xls', 'xlsx', 'csv', 'ods'].includes(ext)) return SPREADSHEET;
+	if (['zip', 'rar', '7z', 'tar', 'gz'].includes(ext)) return ARCHIVE;
+
+	return VISUALS.unknown;
+}

--- a/frontend/src/config/mime.types
+++ b/frontend/src/config/mime.types
@@ -1,34 +1,99 @@
-
 types {
-    application/pdf                       pdf;
-    application/msword                    doc;
-    application/vnd.openxmlformats-officedocument.wordprocessingml.document docx;
-    application/vnd.ms-excel              xls;
-    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet xlsx;
-    application/vnd.ms-powerpoint         ppt;
-    application/vnd.openxmlformats-officedocument.presentationml.presentation pptx;
-    text/plain                            txt md go css tsx ts js html sh yaml yml cpp c h;
-    application/json                      json;
-    application/rtf                       rtf;
+    text/html                                        html htm shtml;
+    text/css                                         css;
+    text/xml                                         xml;
+    image/gif                                        gif;
+    image/jpeg                                       jpeg jpg;
+    application/javascript                           js;
+    application/atom+xml                             atom;
+    application/rss+xml                              rss;
 
-    image/jpeg                            jpeg jpg;
-    image/png                             png;
-    image/gif                             gif;
-    image/webp                            webp;
-    image/svg+xml                         svg;
+    text/mathml                                      mml;
+    text/plain                                       txt;
+    text/vnd.sun.j2me.app-descriptor                 jad;
+    text/vnd.wap.wml                                 wml;
+    text/x-component                                 htc;
 
-    audio/mpeg                            mp3;
-    audio/wav                             wav;
-    audio/ogg                             ogg;
+    image/avif                                       avif;
+    image/png                                        png;
+    image/svg+xml                                    svg svgz;
+    image/tiff                                       tif tiff;
+    image/vnd.wap.wbmp                               wbmp;
+    image/webp                                       webp;
+    image/x-icon                                     ico;
+    image/x-jng                                      jng;
+    image/x-ms-bmp                                   bmp;
 
-    video/mp4                             mp4;
-    video/mpeg                            mpeg mpg;
-    video/quicktime                       mov;
-    video/x-msvideo                       avi;
+    font/woff                                        woff;
+    font/woff2                                       woff2;
 
-    application/zip                       zip;
-    application/x-rar-compressed          rar;
-    application/x-7z-compressed           7z;
-    application/x-tar                     tar;
-    application/x-gzip                    gz;
+    application/java-archive                         jar war ear;
+    application/json                                 json;
+    application/mac-binhex40                         hqx;
+    application/msword                               doc;
+    application/pdf                                  pdf;
+    application/postscript                           ps eps ai;
+    application/rtf                                  rtf;
+    application/vnd.apple.mpegurl                    m3u8;
+    application/vnd.google-earth.kml+xml             kml;
+    application/vnd.google-earth.kmz                 kmz;
+    application/vnd.ms-excel                         xls;
+    application/vnd.ms-fontobject                    eot;
+    application/vnd.ms-powerpoint                    ppt;
+    application/vnd.oasis.opendocument.graphics      odg;
+    application/vnd.oasis.opendocument.presentation  odp;
+    application/vnd.oasis.opendocument.spreadsheet   ods;
+    application/vnd.oasis.opendocument.text          odt;
+    application/vnd.openxmlformats-officedocument.presentationml.presentation
+                                                     pptx;
+    application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+                                                     xlsx;
+    application/vnd.openxmlformats-officedocument.wordprocessingml.document
+                                                     docx;
+    application/vnd.wap.wmlc                         wmlc;
+    application/wasm                                 wasm;
+    application/x-7z-compressed                      7z;
+    application/x-cocoa                              cco;
+    application/x-java-archive-diff                  jardiff;
+    application/x-java-jnlp-file                     jnlp;
+    application/x-makeself                           run;
+    application/x-perl                               pl pm;
+    application/x-pilot                              prc pdb;
+    application/x-rar-compressed                     rar;
+    application/x-redhat-package-manager             rpm;
+    application/x-sea                                sea;
+    application/x-shockwave-flash                    swf;
+    application/x-stuffit                            sit;
+    application/x-tcl                                tcl tk;
+    application/x-x509-ca-cert                       der pem crt;
+    application/x-xpinstall                          xpi;
+    application/xhtml+xml                            xhtml;
+    application/xspf+xml                             xspf;
+    application/zip                                  zip;
+
+    application/octet-stream                         bin exe dll;
+    application/octet-stream                         deb;
+    application/octet-stream                         dmg;
+    application/octet-stream                         iso img;
+    application/octet-stream                         msi msp msm;
+
+    audio/midi                                       mid midi kar;
+    audio/mpeg                                       mp3;
+    audio/ogg                                        ogg;
+    audio/x-m4a                                      m4a;
+    audio/x-realaudio                                ra;
+    audio/flac                                       flac;
+
+    video/3gpp                                       3gpp 3gp;
+    video/mp2t                                       ts;
+    video/mp4                                        mp4;
+    video/mpeg                                       mpeg mpg;
+    video/quicktime                                  mov;
+    video/webm                                       webm;
+    video/x-flv                                      flv;
+    video/x-m4v                                      m4v;
+    video/x-mng                                      mng;
+    video/x-ms-asf                                   asx asf;
+    video/x-ms-wmv                                   wmv;
+    video/x-msvideo                                  avi;
 }

--- a/frontend/src/config/mime.types
+++ b/frontend/src/config/mime.types
@@ -83,6 +83,7 @@ types {
     audio/x-m4a                                      m4a;
     audio/x-realaudio                                ra;
     audio/flac                                       flac;
+    audio/wav                                        wav;
 
     video/3gpp                                       3gpp 3gp;
     video/mp2t                                       ts;

--- a/frontend/src/config/previewType.ts
+++ b/frontend/src/config/previewType.ts
@@ -1,0 +1,57 @@
+export type PreviewKind =
+	| 'image' | 'pdf' | 'markdown' | 'code'
+	| 'text' | 'audio' | 'video' | 'unknown';
+
+export interface PreviewDescriptor {
+	kind: PreviewKind;
+	mime: string;
+}
+
+export const MAX_VIDEO_PREVIEW_BYTES = 500 * 1024 * 1024; // max preview size
+
+const TABLE: Record<string, PreviewDescriptor> = {
+
+	png: { kind: 'image', mime: 'image/png' },
+	jpg: { kind: 'image', mime: 'image/jpeg' },
+	jpeg: { kind: 'image', mime: 'image/jpeg' },
+	gif: { kind: 'image', mime: 'image/gif' },
+	webp: { kind: 'image', mime: 'image/webp' },
+	svg: { kind: 'image', mime: 'image/svg+xml' },
+	bmp: { kind: 'image', mime: 'image/bmp' },
+
+	pdf: { kind: 'pdf', mime: 'application/pdf' },
+	md: { kind: 'markdown', mime: 'text/markdown' },
+	markdown: { kind: 'markdown', mime: 'text/markdown' },
+
+	// code is rendered as source text, never executed
+	go: { kind: 'code', mime: 'text/x-go' },
+	ts: { kind: 'code', mime: 'text/typescript' },
+	tsx: { kind: 'code', mime: 'text/typescript' },
+	js: { kind: 'code', mime: 'text/javascript' },
+	css: { kind: 'code', mime: 'text/css' },
+	html: { kind: 'text', mime: 'text/plain' }, // text/plain on purpose: neutralizes the blob URL
+	sh: { kind: 'code', mime: 'text/x-sh' },
+	yaml: { kind: 'code', mime: 'text/yaml' },
+	yml: { kind: 'code', mime: 'text/yaml' },
+	cpp: { kind: 'code', mime: 'text/x-c++src' },
+	c: { kind: 'code', mime: 'text/x-csrc' },
+	h: { kind: 'code', mime: 'text/x-chdr' },
+	json: { kind: 'code', mime: 'application/json' },
+
+	txt: { kind: 'text', mime: 'text/plain' },
+
+	mp3: { kind: 'audio', mime: 'audio/mpeg' },
+	wav: { kind: 'audio', mime: 'audio/wav' },
+	ogg: { kind: 'audio', mime: 'audio/ogg' },
+	flac: { kind: 'audio', mime: 'audio/flac' },
+
+	mp4: { kind: 'video', mime: 'video/mp4' },
+	webm: { kind: 'video', mime: 'video/webm' },
+};
+
+const UNKNOWN: PreviewDescriptor = { kind: 'unknown', mime: 'application/octet-stream' };
+
+export function resolvePreview(filename: string): PreviewDescriptor {
+	const ext = filename.split('.').pop()?.toLowerCase() ?? '';
+	return TABLE[ext] ?? UNKNOWN;
+}

--- a/frontend/src/config/previewType.ts
+++ b/frontend/src/config/previewType.ts
@@ -29,7 +29,7 @@ const TABLE: Record<string, PreviewDescriptor> = {
 	tsx: { kind: 'code', mime: 'text/typescript' },
 	js: { kind: 'code', mime: 'text/javascript' },
 	css: { kind: 'code', mime: 'text/css' },
-	html: { kind: 'text', mime: 'text/plain' }, // text/plain on purpose: neutralizes the blob URL
+	html: { kind: 'code', mime: 'text/plain' },
 	sh: { kind: 'code', mime: 'text/x-sh' },
 	yaml: { kind: 'code', mime: 'text/yaml' },
 	yml: { kind: 'code', mime: 'text/yaml' },

--- a/frontend/src/hooks/useE2EEPreview.ts
+++ b/frontend/src/hooks/useE2EEPreview.ts
@@ -8,6 +8,7 @@ import {
 import { decryptOrgPrivateKey } from '../services/organizations.service';
 import { fetchWithRefresh } from '../services/api.service';
 import { UPLOAD_CONFIG } from '../config/uploadConfig';
+import { resolvePreview } from '../config/previewType';
 
 interface DownloadMetadata {
     presigned_url: string;
@@ -20,35 +21,6 @@ export function useE2EEPreview() {
     const [downloadStatus, setDownloadStatus] = useState<string | null>(null);
     const [isDownloading, setIsDownloading] = useState(false);
     const [downloadError, setDownloadError] = useState(false);
-
-    const getMimeTypeByExtension = (filename: string): string => {
-        const ext = filename.split('.').pop()?.toLowerCase() || '';
-        switch (ext) {
-            case 'pdf': return 'application/pdf';
-            case 'png': return 'image/png';
-            case 'jpg':
-            case 'jpeg': return 'image/jpeg';
-            case 'gif': return 'image/gif';
-            case 'webp': return 'image/webp';
-            case 'svg': return 'image/svg+xml';
-            case 'bmp': return 'image/bmp';
-            case 'json': return 'application/json';
-            case 'txt':
-            case 'md':
-            case 'html':
-            case 'css':
-            case 'js':
-            case 'ts':
-            case 'tsx':
-            case 'go':
-            case 'sh':
-            case 'yaml':
-            case 'yml':
-                return 'text/plain';
-            default:
-                return 'application/octet-stream';
-        }
-    };
 
     const decryptForPreview = async (
         fileId: string,
@@ -215,8 +187,8 @@ export function useE2EEPreview() {
             }
 
             if (signal?.aborted) return null;
-            const mimeType = getMimeTypeByExtension(filename);
-            const blob = new Blob(decryptedChunks, { type: mimeType });
+            const { mime } = resolvePreview(filename);
+            const blob = new Blob(decryptedChunks, { type: mime });
 
             return { blob, filename };
         } catch (err: any) {
@@ -239,4 +211,3 @@ export function useE2EEPreview() {
 
     return { decryptForPreview, downloadStatus, isDownloading, downloadError };
 }
-

--- a/frontend/src/services/fileValidation.service.ts
+++ b/frontend/src/services/fileValidation.service.ts
@@ -55,6 +55,11 @@ export async function validateFile(file: File): Promise<ValidationResult>  {
 
         const buffer = await file.slice(0, 4100).arrayBuffer();
         const typeInfo = await fileTypeFromBuffer(new Uint8Array(buffer));
+
+        // When file-type returns null, the file uses a text-based format with no magic bytes.
+        // For these formats, content-based validation is not possible: file.type is OS-dependent
+        // and unreliable across browsers and platforms. Binary formats that could be spoofed
+        // always produce a non-null typeInfo.
         const detectedMime = typeInfo ? typeInfo.mime : expectedMime;
 
         if (detectedMime !== expectedMime) {

--- a/frontend/src/services/fileValidation.service.ts
+++ b/frontend/src/services/fileValidation.service.ts
@@ -55,26 +55,16 @@ export async function validateFile(file: File): Promise<ValidationResult>  {
 
         const buffer = await file.slice(0, 4100).arrayBuffer();
         const typeInfo = await fileTypeFromBuffer(new Uint8Array(buffer));
-        let detectedMime = typeInfo?.mime || file.type;
-
-        if (!typeInfo) {
-            if (['txt', 'md', 'go', 'css', 'tsx', 'ts', 'js', 'html', 'sh', 'yaml', 'yml', 'cpp', 'c', 'h'].includes(extension)) {
-                detectedMime = 'text/plain';
-            } else if (extension === 'rtf') {
-                detectedMime = 'application/rtf';
-            } else if (extension === 'json') {
-                detectedMime = 'application/json';
-            }
-        }
+        const detectedMime = typeInfo ? typeInfo.mime : expectedMime;
 
         if (detectedMime !== expectedMime) {
-             return {
+            return {
                 isValid: false,
-                error: `The .${extension} extension does not match the file content (${detectedMime || 'Unknown'}).`
+                error: `The .${extension} extension does not match the file content (${detectedMime}).`
             };
         }
 
-    } catch (err) {
+    } catch {
         return {
             isValid: false,
             error: "Error while analyzing the file content."
@@ -82,7 +72,7 @@ export async function validateFile(file: File): Promise<ValidationResult>  {
     }
 
     return { isValid: true };
-};
+}
 
 export const formatFileSize = (bytes: number): string => {
     if (bytes === 0) return '0 Bytes';
@@ -100,10 +90,9 @@ export const getDecryptedSize = (encryptedSize: number): number => {
     return encryptedSize - numChunks * 16;
 };
 
-
 export const getFileTypeLabel = (mimeType: string): string => {
     const typeMap: Record<string, string> = {
-        'image/jpeg': ' JPEG Image',
+        'image/jpeg': 'JPEG Image',
         'image/png': 'PNG Image',
         'image/gif': 'GIF Image',
         'image/webp': 'WebP Image',
@@ -117,17 +106,24 @@ export const getFileTypeLabel = (mimeType: string): string => {
         'application/pdf': 'PDF Document',
         'application/rtf': 'RTF Document',
         'text/plain': 'Text File',
+        'text/html': 'HTML File',
+        'text/css': 'CSS File',
+        'application/javascript': 'JavaScript File',
         'text/csv': 'CSV File',
         'application/msword': 'Word Document',
         'application/vnd.openxmlformats-officedocument.wordprocessingml.document': 'Word Document',
-        'application/vnd.ms-excel': 'Excel Folder',
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'Excel Folder',
+        'application/vnd.ms-excel': 'Excel Spreadsheet',
+        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': 'Excel Spreadsheet',
         'application/vnd.ms-powerpoint': 'PowerPoint Presentation',
         'application/vnd.openxmlformats-officedocument.presentationml.presentation': 'PowerPoint Presentation',
         'application/zip': 'ZIP Archive',
         'application/x-rar-compressed': 'RAR Archive',
         'application/x-7z-compressed': '7z Archive',
         'application/json': 'JSON File',
+        'audio/mpeg': 'MP3 Audio',
+        'audio/ogg': 'OGG Audio',
+        'audio/flac': 'FLAC Audio',
+        'audio/wav': 'WAV Audio',
     };
 
     return typeMap[mimeType] || mimeType || 'File';
@@ -136,4 +132,3 @@ export const getFileTypeLabel = (mimeType: string): string => {
 export const getAcceptAttribute = (): string | undefined => {
     return undefined;
 };
-

--- a/infra/caddy/Caddyfile
+++ b/infra/caddy/Caddyfile
@@ -22,6 +22,8 @@
         Content-Security-Policy "
             default-src 'self';
             script-src 'self';
+            frame-src blob:;
+            media-src 'self' blob:;
             style-src 'self' 'unsafe-inline';
             img-src 'self' data: blob:;
             connect-src 'self';

--- a/infra/caddy/Caddyfile.dev
+++ b/infra/caddy/Caddyfile.dev
@@ -44,8 +44,6 @@
         # HSTS (force HTTPS)
         Strict-Transport-Security "max-age=31536000; includeSubDomains"
 
-        # CSP (customize later)
-        # the localhost:9000 connect-src is to test CORS (Cross-Origin Resource Sharing) setup from frontend to minio directly
         Content-Security-Policy "
             default-src 'self';
             script-src 'self';

--- a/infra/caddy/Caddyfile.dev
+++ b/infra/caddy/Caddyfile.dev
@@ -48,27 +48,14 @@
         # the localhost:9000 connect-src is to test CORS (Cross-Origin Resource Sharing) setup from frontend to minio directly
         Content-Security-Policy "
             default-src 'self';
-            frame-src blob:;
             script-src 'self';
+            frame-src blob:;
+            media-src 'self' blob:;
             style-src 'self' 'unsafe-inline';
             img-src 'self' data: blob:;
-            connect-src 'self' http://localhost:9000 https://ostrom.cloud;
+            connect-src 'self';
             frame-ancestors 'none';
         "
-		# Content-Security-Policy "
-		# 	default-src 'self';
-		# 	script-src 'self' 'unsafe-inline' 'unsafe-eval';
-		# 	style-src 'self' 'unsafe-inline';
-		# 	img-src 'self' data: blob:;
-		# 	font-src 'self' data:;
-		# 	connect-src 'self' wss:;
-		# 	frame-ancestors 'self';
-		# "
-
-        # CORS for API
-        # Access-Control-Allow-Origin "*"
-        # Access-Control-Allow-Methods "GET, POST, PUT, DELETE, OPTIONS"
-        # Access-Control-Allow-Headers "Content-Type, Authorization"
     }
 
 

--- a/infra/docker-compose.dev.yml
+++ b/infra/docker-compose.dev.yml
@@ -119,6 +119,7 @@ services:
   adminer:
     container_name: adminer
     image: adminer@sha256:3a1582df310cf49a3c9cad2882496eed4596563f8d33250703f8b26e538cef7d
+    init: true
     networks:
       - dev
     restart: unless-stopped


### PR DESCRIPTION
This PR is a revamp of the preview features.

The way you did the preview made us able to have video preview!
By downloading the complete file when loading the preview frame, we are not limited by the multi-stream we thought we would have at first.

It introduces:

**FileIcon identification and coloring update**
- Centralized the identification on a service file

**More file type preview**
- video, audio
- markdown with specific css to it

**Mime.types**
- mime.types file updated based on the one I found in an nginx:alpine docker container + wav type 


**Infra update**
- Updated Caddyfiles to allow a new media-src CSP that comes form blob (minio objects downloaded)
- adminer PID 1 updated to tini process reaper/signal handler