### PR TITLE
Fix/orga redir

### DIFF
--- a/frontend/src/pages/OrganizationMembers/index.tsx
+++ b/frontend/src/pages/OrganizationMembers/index.tsx
@@ -58,6 +58,8 @@ export default function OrgMembersPage() {
   const { messages, addMessage, removeMessage } = useMessages();
   const allMessages = messages;
 
+  const isLeavingRef = useRef(false);
+
   useEffect(() => {
     return () => { (Object.values(avatarUrlsRef.current) as string[]).forEach(url => URL.revokeObjectURL(url)); };
   }, []);
@@ -91,12 +93,11 @@ export default function OrgMembersPage() {
 
   const fetchMembers = (signal?: AbortSignal) => {
     setMainError(null);
+    if (isLeavingRef.current) return; 
     fetchWithRefresh(`/api/orgs/${id}/members`, { signal })
       .then(res => {
         if (res.status === 404 || res.status === 400) {
-            if (window.location.pathname.includes(`/orgs/${id}`)) {
-              navigate("/404");
-            }
+          navigate("/404");
           return null;
         }
         if (!res.ok) {
@@ -289,11 +290,13 @@ export default function OrgMembersPage() {
 
     const isRemovingMyself = memberToRemove.user_id === myUserId;
     const removedEmail = memberToRemove.email;
+    if (isRemovingMyself) isLeavingRef.current = true;
 
     try {
       const response = await fetchWithRefresh(`/api/orgs/${id}/members/${memberToRemove.user_id}`, { method: "DELETE" });
   
       if (!response.ok) {
+          isLeavingRef.current = false;
           if (response.status === 502 || response.status === 503) {
               setModalError("Network error, please try again later.");
           } else {
@@ -315,6 +318,7 @@ export default function OrgMembersPage() {
       setShowRemoveModal(false);
       setMemberToRemove(null);
     } catch {
+      isLeavingRef.current = false;
       setModalError("Network error, please try again later.");
     }
   };

--- a/frontend/src/pages/OrganizationMembers/index.tsx
+++ b/frontend/src/pages/OrganizationMembers/index.tsx
@@ -153,7 +153,8 @@ export default function OrgMembersPage() {
   }, [id, navigate, status]);
 
   useEffect(() => {
-    const handleMemberChange = () => {
+    const handleMemberChange = (data: any) => {
+      if (data?.user_id && data.user_id === myUserId) return;
       fetchMembers();
     };
 

--- a/frontend/src/pages/OrganizationSettings/OrgSettings.module.css
+++ b/frontend/src/pages/OrganizationSettings/OrgSettings.module.css
@@ -134,6 +134,11 @@
     min-width: 220px;
     outline: none;
     transition: border-color 0.2s ease;
+    max-width: 280px;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .selectMember:focus {
@@ -201,6 +206,7 @@
 
     .selectMember {
         width: 100%;
+        max-width: 100%;
     }
 }
 

--- a/frontend/src/pages/OrganizationSettings/index.tsx
+++ b/frontend/src/pages/OrganizationSettings/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef } from "react";
 import { fetchWithRefresh } from "../../services/api.service";
 import { useParams, useNavigate } from "react-router-dom";
 import { OrgLayout } from "../../components/OrgLayout";
@@ -43,13 +43,15 @@ export default function OrgSettingsPage() {
   const { messages, addMessage, removeMessage } = useMessages();
   const allMessages = messages;
 
+  const isLeavingRef = useRef(false);
+
   const loadOrgSettings = () => {
+    if (isLeavingRef.current) return;
     fetchWithRefresh(`/api/orgs/${id}`)
       .then(res => {
         if (res.status === 404 || res.status === 400) {
-            if (window.location.pathname.includes(`/orgs/${id}`)) {
+          if (isLeavingRef.current) return;
               navigate("/404");
-            }
           return;
         }
         if (!res.ok) {
@@ -118,7 +120,7 @@ export default function OrgSettingsPage() {
     };
 
   const handleMemberChanges = (data: any) => {
-      if (data && (data.org_id === id || data.org_id === undefined)) {
+      if (data && (data.org_id === id || data.org_id === undefined )) {
         loadOrgSettings();
       }
     };
@@ -143,9 +145,11 @@ export default function OrgSettingsPage() {
 
   const handleDeleteOrga = async () => {
     try {
+      isLeavingRef.current = true;
       const response = await fetchWithRefresh(`/api/orgs/${id}`, { method: "DELETE" });
 
       if (!response.ok) {
+          isLeavingRef.current = false;
           if (response.status === 502 || response.status === 503) {
               setError("Network error, please try again later.");
           } else {
@@ -158,6 +162,7 @@ export default function OrgSettingsPage() {
       window.dispatchEvent(new CustomEvent("org-list-changed"));
       navigate("/organizations");
     } catch (err) {
+      isLeavingRef.current = false;
       setError("Network error, please try again.");
     }
   };
@@ -167,9 +172,11 @@ export default function OrgSettingsPage() {
 
   const handleLeaveOrga = async () => {
     try {
+      isLeavingRef.current = true;
       const response = await fetchWithRefresh(`/api/orgs/${id}/members/me`, { method: "DELETE" });
 
       if (!response.ok) {
+          isLeavingRef.current = false;
           if (response.status === 502 || response.status === 503) {
               setModalError("Network error, please try again later.");
           } else {
@@ -178,11 +185,11 @@ export default function OrgSettingsPage() {
           }
           return;
       }
-
       setModalError(null);
       setShowLeaveConfirm(false);
       navigate("/organizations")
     } catch (err) {
+      isLeavingRef.current = false;
       console.error("Network error:", err);
       setModalError("Network error, please try again.");
       return;

--- a/frontend/src/pages/OrganizationSettings/index.tsx
+++ b/frontend/src/pages/OrganizationSettings/index.tsx
@@ -47,7 +47,9 @@ export default function OrgSettingsPage() {
     fetchWithRefresh(`/api/orgs/${id}`)
       .then(res => {
         if (res.status === 404 || res.status === 400) {
-          navigate("/404");
+            if (window.location.pathname.includes(`/orgs/${id}`)) {
+              navigate("/404");
+            }
           return;
         }
         if (!res.ok) {

--- a/frontend/src/pages/OrganizationSettings/index.tsx
+++ b/frontend/src/pages/OrganizationSettings/index.tsx
@@ -50,8 +50,7 @@ export default function OrgSettingsPage() {
     fetchWithRefresh(`/api/orgs/${id}`)
       .then(res => {
         if (res.status === 404 || res.status === 400) {
-          if (isLeavingRef.current) return;
-              navigate("/404");
+          navigate("/404");
           return;
         }
         if (!res.ok) {

--- a/frontend/src/pages/OrganizationSettings/index.tsx
+++ b/frontend/src/pages/OrganizationSettings/index.tsx
@@ -119,6 +119,7 @@ export default function OrgSettingsPage() {
     };
 
   const handleMemberChanges = (data: any) => {
+      if (data?.user_id && data.user_id === userID) return;
       if (data && (data.org_id === id || data.org_id === undefined )) {
         loadOrgSettings();
       }

--- a/frontend/src/styles/auth.module.css
+++ b/frontend/src/styles/auth.module.css
@@ -103,8 +103,8 @@
 
 .input_field {
     width: 100%;
-    padding-left: 18px !important;
-    padding-right: 18px !important;
+    padding-left: 3rem !important;
+    padding-right: 1rem !important;
     padding-top: 18px !important;
     padding-bottom: 18px !important;
     height: var(--input-height);
@@ -114,7 +114,7 @@
     font-size: var(--text-base);
     color: var(--brand-dark);
     transition: var(--transition-base);
-    text-indent: 2.5rem;
+    text-indent: 0;
 }
 
 .input_field:focus {
@@ -123,7 +123,7 @@
 }
 
 .input_field::placeholder {
-    text-indent: 2.5rem;
+    text-indent: 0;
 }
 
 /* ===== BUTTON ===== */


### PR DESCRIPTION
**Fix organization redirection and input field display**

**Changes:**
- Fix incorrect redirection to `/404` when leaving or being removed from an organization, caused by WebSocket events (`MEMBER_REMOVED`, `ORGA_DELETED`) triggering a re-fetch on a resource the user no longer has access to. Fixed using a `isLeavingRef` to block any fetch during navigation.
- Fix input field text overflowing behind the icon on login/register forms by replacing `text-indent` with proper `padding-left`.